### PR TITLE
Fix comment editor width not updating during panel transitions

### DIFF
--- a/src/lib/DiffViewer.svelte
+++ b/src/lib/DiffViewer.svelte
@@ -507,6 +507,9 @@
     function animateUpdate() {
       redrawConnectors();
       updateToolbarPosition();
+      updateCommentEditorPosition();
+      updateLineSelectionToolbar();
+      updateLineCommentEditorPosition();
 
       if (performance.now() - startTime < PANEL_TRANSITION_MS) {
         rafId = requestAnimationFrame(animateUpdate);


### PR DESCRIPTION
## Problem
When the "Add a comment" input is open on the right panel, and hovering over the left panel (which increases left panel size and decreases right panel), the comment input width doesn't change to match the right panel's new size.

## Solution
Added `updateCommentEditorPosition()` and `updateLineCommentEditorPosition()` calls to the panel transition animation effect.

## Root Cause
The panel transition animation effect (triggered by `beforeHovered`, `afterHovered`, `spaceHeld` changes) was only calling:
- `redrawConnectors()`
- `updateToolbarPosition()`

It was missing calls to update the comment editor positions, which recalculate width from `paneRect.width - 24`.