### PR TITLE
Fix comment click not scrolling to correct position

### DIFF
--- a/src/lib/DiffViewer.svelte
+++ b/src/lib/DiffViewer.svelte
@@ -781,27 +781,8 @@
   }
 
   function scrollToLine(lineIndex: number) {
-    if (!afterPane) return;
-
-    const lineElements = afterPane.querySelectorAll('.line');
-    const lineEl = lineElements[lineIndex] as HTMLElement | null;
-    if (!lineEl) return;
-
-    const paneRect = afterPane.getBoundingClientRect();
-    const lineRect = lineEl.getBoundingClientRect();
-
-    if (lineRect.top >= paneRect.top && lineRect.bottom <= paneRect.bottom) {
-      return;
-    }
-
-    const lineTop = lineEl.offsetTop;
-    const paneHeight = afterPane.clientHeight;
-    const targetScroll = lineTop - paneHeight / 2;
-
-    afterPane.scrollTo({
-      top: Math.max(0, targetScroll),
-      behavior: 'smooth',
-    });
+    // Use the scroll controller which manages scrolling via CSS transforms
+    scrollController.scrollToRow(lineIndex, 'after');
   }
 
   // ==========================================================================


### PR DESCRIPTION
scrollToLine was using native DOM scrollTo() but the app uses CSS transforms for scrolling with overflow:hidden. Changed to use scrollController.scrollToRow() which properly updates the scroll state and syncs both panes.