### PR TITLE
Fix comment creation failing in production builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,16 +176,21 @@ fn fetch_pr_branch(
 // =============================================================================
 
 #[tauri::command]
-fn get_review(base: String, head: String) -> Result<Review, String> {
+fn get_review(base: String, head: String, repo_path: Option<String>) -> Result<Review, String> {
     let store = diff::get_store().map_err(|e| e.0)?;
-    let id = make_diff_id(None, &base, &head)?;
+    let id = make_diff_id(repo_path.as_deref(), &base, &head)?;
     store.get_or_create(&id).map_err(|e| e.0)
 }
 
 #[tauri::command]
-fn add_comment(base: String, head: String, comment: NewComment) -> Result<Comment, String> {
+fn add_comment(
+    base: String,
+    head: String,
+    comment: NewComment,
+    repo_path: Option<String>,
+) -> Result<Comment, String> {
     let store = diff::get_store().map_err(|e| e.0)?;
-    let id = make_diff_id(None, &base, &head)?;
+    let id = make_diff_id(repo_path.as_deref(), &base, &head)?;
     let comment = Comment::new(comment.path, comment.span, comment.content);
     store.add_comment(&id, &comment).map_err(|e| e.0)?;
     Ok(comment)

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -50,7 +50,7 @@
       repoState.currentPath ?? undefined,
       diffSelection.spec.useMergeBase
     );
-    await loadComments(diffSelection.spec.base, diffSelection.spec.head);
+    await loadComments(diffSelection.spec.base, diffSelection.spec.head, repoState.currentPath ?? undefined);
     sidebarRef?.setDiffs(diffState.diffs);
   }
 
@@ -70,7 +70,7 @@
       diffSelection.spec.useMergeBase
     );
     // Reload comments - they may have changed after a commit
-    await loadComments(diffSelection.spec.base, diffSelection.spec.head);
+    await loadComments(diffSelection.spec.base, diffSelection.spec.head, repoState.currentPath ?? undefined);
     sidebarRef?.setDiffs(diffState.diffs);
   }
 

--- a/src/lib/CommentEditor.svelte
+++ b/src/lib/CommentEditor.svelte
@@ -39,19 +39,31 @@
     onDelete,
   }: Props = $props();
 
-  let textareaValue = $state('');
+  // Track current input value - use $state for reactivity with initial value
+  let currentValue = $state(existingComment?.content ?? '');
 
-  // Update value when existingComment changes
+  // Update value when existingComment changes (for editing mode)
   $effect(() => {
-    textareaValue = existingComment?.content ?? '';
+    currentValue = existingComment?.content ?? '';
   });
+
+  function handleInput(e: Event) {
+    const target = e.target as HTMLTextAreaElement;
+    currentValue = target.value;
+  }
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
       onCancel();
     } else if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      const content = textareaValue.trim();
+      e.stopPropagation();
+      // Get value directly from event target as fallback
+      const target = e.target as HTMLTextAreaElement;
+      const content = (currentValue || target.value || '').trim();
+
       if (content) {
         onSubmit(content);
       } else {
@@ -73,14 +85,15 @@
 </script>
 
 <div
-  class="comment-editor"
+  class="comment-editor line-comment-editor"
   class:comment-editor-hidden={!visible}
   style="top: {top}px; left: {left}px; width: {width}px;"
 >
   <textarea
     class="comment-textarea"
     {placeholder}
-    bind:value={textareaValue}
+    value={currentValue}
+    oninput={handleInput}
     onkeydown={handleKeydown}
     use:autoFocus
   ></textarea>

--- a/src/lib/services/review.ts
+++ b/src/lib/services/review.ts
@@ -5,9 +5,10 @@ import type { Review, Comment, Edit, NewComment, NewEdit } from '../types';
  * Get or create a review for a diff.
  * @param base - Base ref (SHA)
  * @param head - Head ref (SHA or "WORKDIR" for working tree)
+ * @param repoPath - Optional repository path
  */
-export async function getReview(base: string, head: string): Promise<Review> {
-  return invoke<Review>('get_review', { base, head });
+export async function getReview(base: string, head: string, repoPath?: string): Promise<Review> {
+  return invoke<Review>('get_review', { base, head, repoPath: repoPath ?? null });
 }
 
 /**
@@ -16,9 +17,10 @@ export async function getReview(base: string, head: string): Promise<Review> {
 export async function addComment(
   base: string,
   head: string,
-  comment: NewComment
+  comment: NewComment,
+  repoPath?: string
 ): Promise<Comment> {
-  return invoke<Comment>('add_comment', { base, head, comment });
+  return invoke<Comment>('add_comment', { base, head, comment, repoPath: repoPath ?? null });
 }
 
 /**

--- a/src/lib/stores/comments.svelte.ts
+++ b/src/lib/stores/comments.svelte.ts
@@ -33,6 +33,8 @@ interface CommentsState {
   /** Diff refs for API calls */
   diffBase: string | null;
   diffHead: string | null;
+  /** Repository path for API calls */
+  repoPath: string | null;
   /** Loading state */
   loading: boolean;
 }
@@ -43,6 +45,7 @@ export const commentsState: CommentsState = $state({
   currentPath: null,
   diffBase: null,
   diffHead: null,
+  repoPath: null,
   loading: false,
 });
 
@@ -116,13 +119,14 @@ export function getTotalCommentCount(): number {
  * Load review data (comments and reviewed paths) for a diff.
  * This is the single API call for all review data.
  */
-export async function loadComments(base: string, head: string): Promise<void> {
+export async function loadComments(base: string, head: string, repoPath?: string): Promise<void> {
   commentsState.loading = true;
   commentsState.diffBase = base;
   commentsState.diffHead = head;
+  commentsState.repoPath = repoPath ?? null;
 
   try {
-    const review = await getReview(base, head);
+    const review = await getReview(base, head, repoPath);
     commentsState.comments = review.comments;
     commentsState.reviewedPaths = review.reviewed;
   } catch (e) {
@@ -189,7 +193,12 @@ export async function addComment(
 
   try {
     const newComment: NewComment = { path, span, content };
-    const comment = await apiAddComment(commentsState.diffBase, commentsState.diffHead, newComment);
+    const comment = await apiAddComment(
+      commentsState.diffBase,
+      commentsState.diffHead,
+      newComment,
+      commentsState.repoPath ?? undefined
+    );
     commentsState.comments = [...commentsState.comments, comment];
     return comment;
   } catch (e) {
@@ -277,5 +286,6 @@ export function clearComments(): void {
   commentsState.currentPath = null;
   commentsState.diffBase = null;
   commentsState.diffHead = null;
+  commentsState.repoPath = null;
   commentsState.loading = false;
 }


### PR DESCRIPTION
## Summary
- Fix comment creation not working in production/installed builds while working in dev mode
- Root cause: Review API commands were using "." as the default repository path, which works in dev mode (CWD is the project) but fails in production (app runs from /Applications)

## Changes
- Add `repo_path` parameter to `get_review` and `add_comment` Tauri commands
- Pass `repoPath` through the frontend API layer
- Store `repoPath` in comments state and pass it to all review API calls
- Improve CommentEditor reliability with explicit input handling

## Test plan
- [x] Build production app with `npm run tauri:build`
- [x] Open built app from `src-tauri/target/release/bundle/macos/staged.app`
- [x] Select lines and create a comment
- [x] Press Enter to save - comment should be saved successfully

🤖 Generated with [Claude Code](https://claude.ai/code)