### PR TITLE
Improve file watcher reliability and UI polish

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,8 @@
     setWindowLabel,
     loadTabsFromStorage,
     getActiveTab,
+    markRepoNeedsRefresh,
+    clearNeedsRefresh,
   } from './lib/stores/tabState.svelte';
   import { createDiffState } from './lib/stores/diffState.svelte';
   import { createCommentsState } from './lib/stores/comments.svelte';
@@ -140,12 +142,21 @@
   });
 
   async function handleFilesChanged(changedRepoPath: string) {
-    // Only refresh if this is the active tab's repo
     const activeTab = getActiveTab();
-    if (!activeTab || activeTab.repoPath !== changedRepoPath) return;
+
+    // If this is NOT the active tab's repo, mark those tabs as needing refresh
+    if (!activeTab || activeTab.repoPath !== changedRepoPath) {
+      markRepoNeedsRefresh(changedRepoPath);
+      return;
+    }
 
     // Only refresh if viewing working tree
-    if (diffSelection.spec.head.type !== 'WorkingTree') return;
+    if (diffSelection.spec.head.type !== 'WorkingTree') {
+      // Mark as needing refresh for when user switches back to working tree
+      activeTab.needsRefresh = true;
+      console.debug('[App] Files changed but not viewing working tree, marked for refresh');
+      return;
+    }
 
     await refreshFiles(diffSelection.spec, repoState.currentPath ?? undefined);
     // Reload comments - they may have changed after a commit
@@ -185,6 +196,10 @@
 
     await loadAll();
 
+    // Clear needsRefresh since we just loaded fresh data
+    const tab = getActiveTab();
+    if (tab) clearNeedsRefresh(tab);
+
     // Save updated state back to tab
     syncGlobalToTab();
   }
@@ -195,6 +210,10 @@
     clearReferenceFiles();
     selectCustomDiff(spec, label, prNumber);
     await loadAll();
+
+    // Clear needsRefresh since we just loaded fresh data
+    const tab = getActiveTab();
+    if (tab) clearNeedsRefresh(tab);
 
     // Save updated state back to tab
     syncGlobalToTab();
@@ -402,7 +421,7 @@
    * Handle tab switching.
    * Watcher is already running for the repo - no restart needed.
    */
-  function handleTabSwitch(index: number) {
+  async function handleTabSwitch(index: number) {
     console.log(`Switching to tab ${index}`);
 
     // Save current tab state before switching
@@ -419,6 +438,13 @@
     const tab = getActiveTab();
     if (tab && tab.diffState.currentSpec === null) {
       initializeNewTab(tab);
+    } else if (tab?.needsRefresh && diffSelection.spec.head.type === 'WorkingTree') {
+      // Tab was marked dirty while inactive - refresh now
+      console.debug(`[App] Tab "${tab.repoName}" needs refresh, loading files`);
+      clearNeedsRefresh(tab);
+      await refreshFiles(diffSelection.spec, repoState.currentPath ?? undefined);
+      await loadComments(diffSelection.spec);
+      syncGlobalToTab();
     }
   }
 

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -418,9 +418,10 @@
         class:selected={selectedFile === file.path}
         style="padding-left: 8px"
         onclick={() => selectFile(file)}
+        title={file.path}
       >
         {@render fileIcon(file, showReviewedSection)}
-        <span class="file-name">{file.path}</span>
+        <span class="file-name truncate-start">{file.path}</span>
         {#if file.commentCount > 0}
           <span class="comment-indicator">
             <MessageSquare size={12} />
@@ -553,11 +554,12 @@
                 tabindex="0"
                 onclick={() => onFileSelect?.(refFile.path)}
                 onkeydown={(e) => e.key === 'Enter' && onFileSelect?.(refFile.path)}
+                title={refFile.path}
               >
                 <span class="reference-icon">
                   <Eye size={16} />
                 </span>
-                <span class="file-name">{refFile.path}</span>
+                <span class="file-name truncate-start">{refFile.path}</span>
                 <button
                   class="remove-btn"
                   onclick={(e) => {
@@ -724,6 +726,12 @@
 
   .tree-item.selected {
     background-color: var(--bg-primary);
+    box-shadow: inset 2px 0 0 var(--accent-primary);
+  }
+
+  .tree-item.selected .file-name {
+    color: var(--text-primary);
+    font-weight: 500;
   }
 
   .tree-item:focus-visible {
@@ -770,6 +778,17 @@
     white-space: nowrap;
     min-width: 0;
     color: var(--text-primary);
+  }
+
+  /* Truncate from the beginning (show end of path) */
+  .file-name.truncate-start {
+    direction: rtl;
+    text-align: left;
+  }
+
+  /* Unicode bidi override to keep path segments in correct order */
+  .file-name.truncate-start::before {
+    content: '\200E'; /* Left-to-right mark */
   }
 
   /* Status icon as interactive span */

--- a/src/lib/diffKeyboard.ts
+++ b/src/lib/diffKeyboard.ts
@@ -20,6 +20,8 @@ export interface DiffNavConfig {
   getLineHeight: () => number;
   getViewportHeight: () => number;
   startCommentOnHunk: (hunkIndex: number) => void;
+  /** Called when keyboard navigation focuses a hunk */
+  onHunkFocus?: (hunkIndex: number | null) => void;
 }
 
 const DEFAULT_CONFIG: DiffNavConfig = {
@@ -31,6 +33,7 @@ const DEFAULT_CONFIG: DiffNavConfig = {
   getLineHeight: () => 20,
   getViewportHeight: () => 400,
   startCommentOnHunk: () => {},
+  onHunkFocus: () => {},
 };
 
 /**
@@ -76,6 +79,7 @@ function goToNextHunk(config: DiffNavConfig): boolean {
   if (nextIndex < alignments.length) {
     const nextHunk = alignments[nextIndex].alignment;
     config.scrollToRow(nextHunk.after.start, 'after');
+    config.onHunkFocus?.(nextIndex);
     return true;
   }
 
@@ -116,6 +120,7 @@ function goToPreviousHunk(config: DiffNavConfig): boolean {
     // If we're more than 2 lines into the current hunk, go to its start
     if (anchorRow > currentHunk.after.start + 2) {
       config.scrollToRow(currentHunk.after.start, 'after');
+      config.onHunkFocus?.(currentIndex);
       return true;
     }
 
@@ -123,6 +128,7 @@ function goToPreviousHunk(config: DiffNavConfig): boolean {
     if (currentIndex > 0) {
       const prevHunk = alignments[currentIndex - 1].alignment;
       config.scrollToRow(prevHunk.after.start, 'after');
+      config.onHunkFocus?.(currentIndex - 1);
       return true;
     }
   }
@@ -130,6 +136,7 @@ function goToPreviousHunk(config: DiffNavConfig): boolean {
   // If at or before first hunk, go to first hunk
   if (alignments.length > 0) {
     config.scrollToRow(alignments[0].alignment.after.start, 'after');
+    config.onHunkFocus?.(0);
     return true;
   }
 


### PR DESCRIPTION
File watcher fixes:
- Use atomic watch_id to handle re-registration without losing events
- Add logging for debugging when events are dropped
- Track dirty state for tabs to refresh when switching back
- Add error handling for watch/unwatch invoke calls

Sidebar improvements:
- Truncate long file paths from the beginning (show end of path)
- Add tooltip showing full path on hover
- Improve selected file highlighting with accent border

Diff viewer:
- Add visual highlight for keyboard-navigated hunk (J/K keys)
- Blue accent bar and background on focused hunk