### PR TITLE
Upgrade svelte to 5.46.4 to fix CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/node": "^24.10.1",
         "prettier": "^3.7.4",
         "prettier-plugin-svelte": "^3.4.1",
-        "svelte": "^5.43.8",
+        "svelte": "^5.46.4",
         "svelte-check": "^4.3.4",
         "typescript": "~5.9.3",
         "vite": "^7.2.4"
@@ -1371,9 +1371,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.1",
-      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/devalue/-/devalue-5.6.1.tgz",
-      "integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
+      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -1953,9 +1953,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.46.0",
-      "resolved": "https://global.block-artifacts.com/artifactory/api/npm/square-npm/svelte/-/svelte-5.46.0.tgz",
-      "integrity": "sha512-ZhLtvroYxUxr+HQJfMZEDRsGsmU46x12RvAv/zi9584f5KOX7bUrEbhPJ7cKFmUvZTJXi/CFZUYwDC6M1FigPw==",
+      "version": "5.46.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.4.tgz",
+      "integrity": "sha512-VJwdXrmv9L8L7ZasJeWcCjoIuMRVbhuxbss0fpVnR8yorMmjNDwcjIH08vS6wmSzzzgAG5CADQ1JuXPS2nwt9w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1967,7 +1967,7 @@
         "aria-query": "^5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.5.0",
+        "devalue": "^5.6.2",
         "esm-env": "^1.2.1",
         "esrap": "^2.2.1",
         "is-reference": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^24.10.1",
     "prettier": "^3.7.4",
     "prettier-plugin-svelte": "^3.4.1",
-    "svelte": "^5.43.8",
+    "svelte": "^5.46.4",
     "svelte-check": "^4.3.4",
     "typescript": "~5.9.3",
     "vite": "^7.2.4"


### PR DESCRIPTION
## Summary

Addresses security vulnerabilities disclosed in the [Svelte security blog post](https://svelte.dev/blog/cves-affecting-the-svelte-ecosystem).

## Changes

| Package | Before | After |
|---------|--------|-------|
| svelte | 5.46.0 | 5.46.4 |
| devalue | 5.6.1 | 5.6.2 (transitive) |

## CVEs Addressed

- **CVE-2026-22775**: DoS in devalue.parse due to memory/CPU exhaustion
- **CVE-2026-22774**: DoS in devalue.parse due to memory exhaustion

These affect applications parsing user-controlled input through devalue.