### PR TITLE
Fix Branch Changes mode using stale merge-base when switching branches

### DIFF
--- a/src-tauri/src/git/diff.rs
+++ b/src-tauri/src/git/diff.rs
@@ -1,8 +1,29 @@
 use super::cli::{self, GitError};
+use super::refs;
 use super::types::*;
 use git2::{DiffOptions, Repository};
 use std::cell::RefCell;
 use std::path::Path;
+
+/// Resolve a GitRef, converting MergeBase to a concrete SHA.
+fn resolve_ref(repo: &Path, git_ref: &GitRef) -> Result<GitRef, GitError> {
+    match git_ref {
+        GitRef::MergeBase => {
+            let default_branch = refs::detect_default_branch(repo)?;
+            let sha = refs::merge_base(repo, &default_branch, "HEAD")?;
+            Ok(GitRef::Rev(sha))
+        }
+        other => Ok(other.clone()),
+    }
+}
+
+/// Resolve a DiffSpec, converting any MergeBase refs to concrete SHAs.
+fn resolve_spec(repo: &Path, spec: &DiffSpec) -> Result<DiffSpec, GitError> {
+    Ok(DiffSpec {
+        base: resolve_ref(repo, &spec.base)?,
+        head: resolve_ref(repo, &spec.head)?,
+    })
+}
 
 /// A hunk from git diff (0-indexed line numbers)
 #[derive(Debug, Clone, Copy)]
@@ -25,6 +46,9 @@ struct Hunk {
 /// For commit..commit diffs: uses `git diff --name-status -z` since status doesn't
 /// support arbitrary commit ranges.
 pub fn list_diff_files(repo: &Path, spec: &DiffSpec) -> Result<Vec<FileDiffSummary>, GitError> {
+    // Resolve MergeBase to concrete SHA
+    let spec = resolve_spec(repo, spec)?;
+
     match (&spec.base, &spec.head) {
         (GitRef::Rev(base), GitRef::WorkingTree) => {
             // Working tree diff - use git status for fsmonitor support
@@ -39,6 +63,9 @@ pub fn list_diff_files(repo: &Path, spec: &DiffSpec) -> Result<Vec<FileDiffSumma
         (GitRef::WorkingTree, _) => Err(GitError::CommandFailed(
             "Cannot use working tree as base".to_string(),
         )),
+        (GitRef::MergeBase, _) | (_, GitRef::MergeBase) => {
+            unreachable!("MergeBase should have been resolved")
+        }
     }
 }
 
@@ -249,6 +276,9 @@ fn parse_name_status(output: &str) -> Result<Vec<FileDiffSummary>, GitError> {
 /// This is reliable and battle-tested - we use git CLI only for list_diff_files
 /// where fsmonitor support matters for performance.
 pub fn get_file_diff(repo_path: &Path, spec: &DiffSpec, path: &Path) -> Result<FileDiff, GitError> {
+    // Resolve MergeBase to concrete SHA
+    let spec = resolve_spec(repo_path, spec)?;
+
     let repo = Repository::discover(repo_path).map_err(|e| GitError::NotARepo(e.to_string()))?;
 
     // Resolve trees
@@ -284,6 +314,7 @@ pub fn get_file_diff(repo_path: &Path, spec: &DiffSpec, path: &Path) -> Result<F
 }
 
 /// Resolve a GitRef to a tree (or None for working tree)
+/// Note: MergeBase should already be resolved before calling this
 fn resolve_to_tree<'a>(
     repo: &'a Repository,
     git_ref: &GitRef,
@@ -298,6 +329,9 @@ fn resolve_to_tree<'a>(
                 GitError::CommandFailed(format!("Cannot get tree for '{}': {}", rev, e))
             })?;
             Ok(Some(tree))
+        }
+        GitRef::MergeBase => {
+            unreachable!("MergeBase should have been resolved before calling resolve_to_tree")
         }
     }
 }

--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -14,5 +14,5 @@ pub use github::{
     check_github_auth, fetch_pr, invalidate_cache as invalidate_pr_cache, list_pull_requests,
     sync_review_to_github, GitHubAuthStatus, GitHubSyncResult, PullRequest,
 };
-pub use refs::{get_repo_root, list_refs, merge_base, resolve_ref};
+pub use refs::{detect_default_branch, get_repo_root, list_refs, merge_base, resolve_ref};
 pub use types::*;

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -35,23 +35,29 @@ pub enum GitRef {
     WorkingTree,
     /// Anything that resolves to a commit: SHA, branch, tag, origin/main, HEAD~3, etc.
     Rev(String),
+    /// Merge-base between the default branch and HEAD.
+    /// Resolved dynamically at diff-time to handle branch switches.
+    MergeBase,
 }
 
 impl GitRef {
     /// String representation for git commands
     /// WorkingTree is represented as empty string (git uses working tree by default)
+    /// MergeBase should be resolved before calling this
     pub fn as_git_arg(&self) -> Option<&str> {
         match self {
             GitRef::WorkingTree => None,
             GitRef::Rev(s) => Some(s),
+            GitRef::MergeBase => panic!("MergeBase must be resolved before use"),
         }
     }
 
-    /// Display representation (@ for working tree)
+    /// Display representation (@ for working tree, merge-base for MergeBase)
     pub fn display(&self) -> &str {
         match self {
             GitRef::WorkingTree => "@",
             GitRef::Rev(s) => s,
+            GitRef::MergeBase => "merge-base",
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,12 @@ fn make_diff_id(repo: &Path, spec: &DiffSpec) -> Result<DiffId, String> {
         match r {
             GitRef::WorkingTree => Ok("@".to_string()),
             GitRef::Rev(rev) => git::resolve_ref(repo, rev).map_err(|e| e.to_string()),
+            GitRef::MergeBase => {
+                // Resolve merge-base to a concrete SHA for stable storage key
+                let default_branch =
+                    git::detect_default_branch(repo).map_err(|e| e.to_string())?;
+                git::merge_base(repo, &default_branch, "HEAD").map_err(|e| e.to_string())
+            }
         }
     };
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -9,7 +9,7 @@
   import TopBar from './lib/TopBar.svelte';
   import FileSearchModal from './lib/FileSearchModal.svelte';
   import TabBar from './lib/TabBar.svelte';
-  import { listRefs, getMergeBase } from './lib/services/git';
+  import { listRefs } from './lib/services/git';
   import { getWindowLabel } from './lib/services/window';
   import {
     windowState,
@@ -25,7 +25,7 @@
   import { createDiffState } from './lib/stores/diffState.svelte';
   import { createCommentsState } from './lib/stores/comments.svelte';
   import { createDiffSelection } from './lib/stores/diffSelection.svelte';
-  import { DiffSpec, inferRefType } from './lib/types';
+  import { DiffSpec, gitRefName } from './lib/types';
   import type { DiffSpec as DiffSpecType } from './lib/types';
   import { initWatcher, watchRepo, type Unsubscribe } from './lib/services/statusEvents';
   import { referenceFileAsDiff } from './lib/diffUtils';
@@ -55,8 +55,7 @@
     selectPreset,
     selectCustomDiff,
     resetDiffSelection,
-    setDefaultBranch,
-    getDefaultBranch,
+
     type DiffPreset,
   } from './lib/stores/diffSelection.svelte';
   import {
@@ -177,28 +176,7 @@
     clearReferenceFiles();
     clearSmartDiffResults();
 
-    // Branch Changes uses merge-base for cleaner diffs
-    if (preset.label === 'Branch Changes') {
-      try {
-        const mergeBaseSha = await getMergeBase(
-          getDefaultBranch(),
-          'HEAD',
-          repoState.currentPath ?? undefined
-        );
-        const spec: DiffSpecType = {
-          base: { type: 'Rev', value: mergeBaseSha },
-          head: { type: 'WorkingTree' },
-        };
-        selectCustomDiff(spec, preset.label);
-      } catch (e) {
-        console.error('Failed to compute merge-base:', e);
-        diffState.error = `Failed to compute merge base: ${e}`;
-        diffState.loading = false;
-        return;
-      }
-    } else {
-      selectPreset(preset);
-    }
+    selectPreset(preset);
 
     await loadAll();
 
@@ -236,11 +214,9 @@
     if (repoState.currentPath) {
       watchRepo(repoState.currentPath);
 
-      // Load refs and detect default branch for new repo
+      // Validate repo by loading refs
       try {
-        const refs = await listRefs(repoState.currentPath);
-        const defaultBranch = detectDefaultBranch(refs);
-        setDefaultBranch(defaultBranch);
+        await listRefs(repoState.currentPath);
         // Mark repo as valid since we got refs
         setCurrentRepo(repoState.currentPath);
       } catch (e) {
@@ -301,25 +277,6 @@
     // Close the current window
     const window = getCurrentWindow();
     await window.close();
-  }
-
-  /**
-   * Detect the default branch (main, master, etc.) from available refs.
-   */
-  function detectDefaultBranch(refs: string[]): string {
-    // Filter to likely branch names (not remotes, not tags)
-    const branchNames = refs.filter((r) => inferRefType(r) === 'branch');
-
-    // Check common default branch names in order of preference
-    const candidates = ['main', 'master', 'develop', 'trunk'];
-    for (const name of candidates) {
-      if (branchNames.includes(name)) {
-        return name;
-      }
-    }
-
-    // Fallback to first branch, or 'main' if no branches
-    return branchNames[0] ?? 'main';
   }
 
   /**
@@ -404,10 +361,8 @@
    */
   async function initializeNewTab(tab: any) {
     try {
-      // Load refs and detect default branch
-      const refs = await listRefs(tab.repoPath);
-      const defaultBranch = detectDefaultBranch(refs);
-      setDefaultBranch(defaultBranch);
+      // Validate repo by loading refs
+      await listRefs(tab.repoPath);
 
       // Reset to uncommitted preset
       resetDiffSelection();
@@ -510,8 +465,7 @@
     try {
       // Determine which ref to use for loading the file
       // Use the "head" ref of the current diff
-      const headRef = diffSelection.spec.head;
-      const refName = headRef.type === 'WorkingTree' ? 'HEAD' : headRef.value;
+      const refName = gitRefName(diffSelection.spec.head);
       await addReferenceFile(refName, path, diffSelection.spec, repoState.currentPath ?? undefined);
       showFileSearch = false;
       // Select the newly added file
@@ -696,9 +650,8 @@
 </main>
 
 {#if showFileSearch}
-  {@const headRef = diffSelection.spec.head}
   <FileSearchModal
-    refName={headRef.type === 'WorkingTree' ? 'HEAD' : headRef.value}
+    refName={gitRefName(diffSelection.spec.head)}
     repoPath={repoState.currentPath ?? undefined}
     existingPaths={[
       ...diffState.files

--- a/src/lib/DiffViewer.svelte
+++ b/src/lib/DiffViewer.svelte
@@ -46,7 +46,7 @@
   import { setupDiffKeyboardNav } from './diffKeyboard';
   import { diffSelection } from './stores/diffSelection.svelte';
   import { diffState, clearScrollTarget } from './stores/diffState.svelte';
-  import { DiffSpec } from './types';
+  import { DiffSpec, gitRefDisplay } from './types';
   import CommentEditor from './CommentEditor.svelte';
   import AnnotationOverlay from './AnnotationOverlay.svelte';
   import { smartDiffState, setAnnotationsRevealed } from './stores/smartDiff.svelte';
@@ -86,11 +86,11 @@
 
   // Get diff spec from store for display and logic
   let isWorkingTree = $derived(diffSelection.spec.head.type === 'WorkingTree');
-  let diffBaseDisplay = $derived(
-    diffSelection.spec.base.type === 'WorkingTree' ? '@' : diffSelection.spec.base.value
-  );
+  let diffBaseDisplay = $derived(gitRefDisplay(diffSelection.spec.base));
   let diffHeadDisplay = $derived(
-    diffSelection.spec.head.type === 'WorkingTree' ? 'Working Tree' : diffSelection.spec.head.value
+    diffSelection.spec.head.type === 'WorkingTree'
+      ? 'Working Tree'
+      : gitRefDisplay(diffSelection.spec.head)
   );
 
   // ==========================================================================

--- a/src/lib/TopBar.svelte
+++ b/src/lib/TopBar.svelte
@@ -25,7 +25,7 @@
   import KeyboardShortcutsModal from './KeyboardShortcutsModal.svelte';
   import SettingsModal from './SettingsModal.svelte';
   import SmartDiffModal from './SmartDiffModal.svelte';
-  import { DiffSpec } from './types';
+  import { DiffSpec, gitRefDisplay } from './types';
   import type { DiffSpec as DiffSpecType } from './types';
   import {
     getPresets,
@@ -202,14 +202,14 @@
    * Get initial base string for the custom modal
    */
   function getInitialBase(): string {
-    return diffSelection.spec.base.type === 'WorkingTree' ? '@' : diffSelection.spec.base.value;
+    return gitRefDisplay(diffSelection.spec.base);
   }
 
   /**
    * Get initial head string for the custom modal
    */
   function getInitialHead(): string {
-    return diffSelection.spec.head.type === 'WorkingTree' ? '@' : diffSelection.spec.head.value;
+    return gitRefDisplay(diffSelection.spec.head);
   }
 
   // Close dropdowns when clicking outside

--- a/src/lib/stores/comments.svelte.ts
+++ b/src/lib/stores/comments.svelte.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Comment, Span, NewComment, DiffSpec } from '../types';
+import { gitRefName } from '../types';
 import {
   getReview,
   addComment as apiAddComment,
@@ -170,7 +171,7 @@ export async function loadComments(spec: DiffSpec, repoPath?: string): Promise<v
 
     // Load reference files if any were persisted
     if (review.reference_files.length > 0 && onReferenceFilesLoaded) {
-      const refName = spec.head.type === 'WorkingTree' ? 'HEAD' : spec.head.value;
+      const refName = gitRefName(spec.head);
       // Don't await - let it load in background
       onReferenceFilesLoaded(review.reference_files, refName, repoPath ?? undefined).catch((e) => {
         console.error('Failed to load reference files:', e);

--- a/src/lib/stores/diffSelection.svelte.ts
+++ b/src/lib/stores/diffSelection.svelte.ts
@@ -48,7 +48,7 @@ export interface PresetStore {
 function createDefaultPresets(): DiffPreset[] {
   return [
     { spec: DiffSpec.uncommitted(), label: 'Uncommitted' },
-    { spec: DiffSpec.uncommitted(), label: 'Branch Changes' }, // Base updated on init
+    { spec: DiffSpec.branchChanges(), label: 'Branch Changes' },
     { spec: DiffSpec.lastCommit(), label: 'Last Commit' },
   ];
 }
@@ -92,33 +92,7 @@ export function getPresets(): readonly DiffPreset[] {
   return presetStore.presets;
 }
 
-/** Detected default branch for merge-base computation */
-let defaultBranch = 'origin/main';
 
-/** Get the detected default branch */
-export function getDefaultBranch(): string {
-  return defaultBranch;
-}
-
-/**
- * Update the "Branch Changes" preset to use the detected default branch.
- * Called during app initialization.
- */
-export function setDefaultBranch(branch: string): void {
-  defaultBranch = branch;
-  presetStore.presets = presetStore.presets.map((preset) => {
-    if (preset.label === 'Branch Changes') {
-      return {
-        ...preset,
-        spec: {
-          base: { type: 'Rev', value: branch },
-          head: { type: 'WorkingTree' },
-        },
-      };
-    }
-    return preset;
-  });
-}
 
 /**
  * Diff selection state object.


### PR DESCRIPTION
## Problem

When using 'Branch Changes' mode, the diff viewer computes `merge-base(origin/main, HEAD)` once when you click the preset, and stores the resulting SHA. If you then switch git branches externally (e.g., `git checkout other-branch`), the app continues using the stale merge-base SHA from the previous branch.

This causes the diff to show thousands of unrelated files instead of just the branch's changes.

## Root Cause

The frontend computed the merge-base and stored a concrete SHA in the tab's `diffSelection.spec`. When the branch changed, this stored SHA became invalid but was still used.

## Solution

Move merge-base resolution to the backend and make it dynamic:

1. **Add `MergeBase` variant to `GitRef`** - A new ref type that means "compute merge-base at diff-time"
2. **Backend detects default branch** - New `detect_default_branch()` function that scans for origin/main, origin/master, etc.
3. **Backend resolves `MergeBase` dynamically** - `list_diff_files()` and `get_file_diff()` now resolve `MergeBase` to a concrete SHA before diffing
4. **Simplified frontend** - Removed default branch detection and special-case handling

## Files Changed

- `src-tauri/src/git/types.rs` - Added `MergeBase` variant
- `src-tauri/src/git/refs.rs` - Added `detect_default_branch()`
- `src-tauri/src/git/diff.rs` - Added `resolve_spec()` to resolve `MergeBase` before diffing
- `src-tauri/src/lib.rs` - Handle `MergeBase` in `make_diff_id()`
- `src/lib/types.ts` - Added `MergeBase` variant and helper functions
- `src/lib/stores/diffSelection.svelte.ts` - Simplified presets
- `src/App.svelte` - Removed special-case merge-base logic
- Various display components - Use new helper functions

Fixes TSK-3918