### PR TITLE
feat: add folder picker modal for quick repo switching

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,264 @@ fn make_diff_id(repo: &Path, spec: &DiffSpec) -> Result<DiffId, String> {
 // File Browsing Commands
 // =============================================================================
 
+/// Entry in a directory listing.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DirEntry {
+    name: String,
+    path: String,
+    is_dir: bool,
+    is_repo: bool,
+}
+
+/// List contents of a directory.
+/// Returns directories first (sorted), then files (sorted).
+/// For directories, also indicates if they are git repositories.
+#[tauri::command(rename_all = "camelCase")]
+fn list_directory(path: String) -> Result<Vec<DirEntry>, String> {
+    let dir = Path::new(&path);
+
+    if !dir.exists() {
+        return Err(format!("Directory does not exist: {}", path));
+    }
+
+    if !dir.is_dir() {
+        return Err(format!("Not a directory: {}", path));
+    }
+
+    let mut dirs = Vec::new();
+    let mut files = Vec::new();
+
+    let entries = std::fs::read_dir(dir).map_err(|e| format!("Failed to read directory: {}", e))?;
+
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+
+        // Skip hidden files/directories
+        if name.starts_with('.') {
+            continue;
+        }
+
+        let entry_path = entry.path();
+        let is_dir = entry_path.is_dir();
+        let is_repo = is_dir && entry_path.join(".git").exists();
+
+        let item = DirEntry {
+            name,
+            path: entry_path.to_string_lossy().to_string(),
+            is_dir,
+            is_repo,
+        };
+
+        if is_dir {
+            dirs.push(item);
+        } else {
+            files.push(item);
+        }
+    }
+
+    // Sort alphabetically (case-insensitive)
+    dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+
+    // Directories first, then files
+    dirs.extend(files);
+    Ok(dirs)
+}
+
+/// Folders to skip during search - system folders unlikely to contain projects.
+const SKIP_FOLDERS: &[&str] = &[
+    // macOS system
+    "Library",
+    "Applications",
+    "System",
+    "Volumes",
+    "cores",
+    "private",
+    // Common non-project folders
+    "node_modules",
+    "target",
+    "build",
+    "dist",
+    "vendor",
+    ".git",
+    "__pycache__",
+    "venv",
+    ".venv",
+    "env",
+    ".cargo",
+    ".rustup",
+    ".npm",
+    ".cache",
+    "Caches",
+    // Media/documents unlikely to have repos
+    "Movies",
+    "Music",
+    "Pictures",
+    "Photos Library.photoslibrary",
+];
+
+/// Common development folder names - search these when at home directory.
+const DEV_FOLDERS: &[&str] = &[
+    "dev",
+    "projects",
+    "code",
+    "repos",
+    "src",
+    "workspace",
+    "work",
+    "github",
+    "gitlab",
+    "Development",
+    "Documents",
+    "Desktop",
+];
+
+/// Search for git repositories matching a query.
+/// Only returns directories containing a .git folder.
+/// When at home directory, only searches inside common dev folders.
+/// Returns up to `limit` matches sorted by relevance.
+#[tauri::command(rename_all = "camelCase")]
+fn search_directories(
+    path: String,
+    query: String,
+    max_depth: Option<u32>,
+    limit: Option<usize>,
+) -> Result<Vec<DirEntry>, String> {
+    let dir = Path::new(&path);
+    let max_depth = max_depth.unwrap_or(6);
+    let limit = limit.unwrap_or(20);
+    let query_lower = query.to_lowercase();
+
+    if !dir.exists() || !dir.is_dir() {
+        return Err(format!("Invalid directory: {}", path));
+    }
+
+    let mut results = Vec::new();
+    let collect_limit = limit * 3;
+
+    // Check if we're at the home directory
+    let home_dir = dirs::home_dir();
+    let is_home = home_dir.as_ref().is_some_and(|h| h == dir);
+
+    if is_home {
+        // When at home, only search inside common dev folders
+        for dev_folder in DEV_FOLDERS {
+            let dev_path = dir.join(dev_folder);
+            if dev_path.exists() && dev_path.is_dir() {
+                search_repos_recursive(
+                    &dev_path,
+                    &query_lower,
+                    0,
+                    max_depth,
+                    &mut results,
+                    collect_limit,
+                );
+                if results.len() >= collect_limit {
+                    break;
+                }
+            }
+        }
+    } else {
+        // Normal recursive search for non-home directories
+        search_repos_recursive(dir, &query_lower, 0, max_depth, &mut results, collect_limit);
+    }
+
+    // Sort results by relevance:
+    // 1. Exact matches first
+    // 2. Then by path depth (shallower = better)
+    results.sort_by(|a, b| {
+        let a_exact = a.name.to_lowercase() == query_lower;
+        let b_exact = b.name.to_lowercase() == query_lower;
+        if a_exact != b_exact {
+            return b_exact.cmp(&a_exact); // exact matches first
+        }
+
+        let a_depth = a.path.matches('/').count();
+        let b_depth = b.path.matches('/').count();
+        a_depth.cmp(&b_depth) // shallower first
+    });
+    results.truncate(limit);
+
+    Ok(results)
+}
+
+/// Recursive helper for searching git repositories.
+/// Only adds directories that contain a .git folder.
+/// Returns true if we should stop searching (hit the limit).
+fn search_repos_recursive(
+    dir: &Path,
+    query: &str,
+    depth: u32,
+    max_depth: u32,
+    results: &mut Vec<DirEntry>,
+    limit: usize,
+) -> bool {
+    if depth > max_depth || results.len() >= limit {
+        return results.len() >= limit;
+    }
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+
+        // Skip hidden directories
+        if name.starts_with('.') {
+            continue;
+        }
+
+        // Skip system/non-project folders
+        if SKIP_FOLDERS.contains(&name.as_str()) {
+            continue;
+        }
+
+        let entry_path = entry.path();
+        if !entry_path.is_dir() {
+            continue;
+        }
+
+        // Check if this is a git repository
+        let is_repo = entry_path.join(".git").exists();
+
+        if is_repo {
+            // Only add if name matches query
+            let name_lower = name.to_lowercase();
+            if query.is_empty() || name_lower.starts_with(query) || name_lower.contains(query) {
+                results.push(DirEntry {
+                    name: name.clone(),
+                    path: entry_path.to_string_lossy().to_string(),
+                    is_dir: true,
+                    is_repo: true,
+                });
+
+                if results.len() >= limit {
+                    return true;
+                }
+            }
+            // Don't recurse into repos (nested repos are rare)
+        } else {
+            // Not a repo, recurse to find repos inside
+            if search_repos_recursive(&entry_path, query, depth + 1, max_depth, results, limit) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Get the user's home directory.
+#[tauri::command]
+fn get_home_dir() -> Result<String, String> {
+    dirs::home_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .ok_or_else(|| "Could not determine home directory".to_string())
+}
+
 /// Search for files matching a query in the repository.
 ///
 /// Uses fuzzy matching - returns up to `limit` matches sorted by relevance.
@@ -622,6 +880,9 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             // File browsing commands
+            list_directory,
+            search_directories,
+            get_home_dir,
             search_files,
             get_file_at_ref,
             // Git commands

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   import EmptyState from './lib/EmptyState.svelte';
   import TopBar from './lib/TopBar.svelte';
   import FileSearchModal from './lib/FileSearchModal.svelte';
+  import FolderPickerModal from './lib/FolderPickerModal.svelte';
   import TabBar from './lib/TabBar.svelte';
   import { listRefs, getMergeBase } from './lib/services/git';
   import { getWindowLabel } from './lib/services/window';
@@ -78,7 +79,8 @@
     repoState,
     initRepoState,
     setCurrentRepo,
-    openRepoPicker,
+    openRepo,
+    getRecentRepos,
   } from './lib/stores/repoState.svelte';
   import {
     clearResults as clearSmartDiffResults,
@@ -88,6 +90,7 @@
   // UI State
   let unsubscribeWatcher: Unsubscribe | null = null;
   let showFileSearch = $state(false);
+  let showFolderPicker = $state(false);
   let unsubscribeMenuOpenFolder: Unsubscribe | null = null;
   let unsubscribeMenuCloseTab: Unsubscribe | null = null;
   let unsubscribeMenuCloseWindow: Unsubscribe | null = null;
@@ -460,11 +463,20 @@
   }
 
   /**
-   * Handle new tab creation.
+   * Handle new tab creation - show the folder picker modal.
    */
-  async function handleNewTab() {
-    const repoPath = await openRepoPicker();
-    if (!repoPath) return;
+  function handleNewTab() {
+    showFolderPicker = true;
+  }
+
+  /**
+   * Handle folder selection from the picker modal.
+   */
+  async function handleFolderSelect(repoPath: string) {
+    showFolderPicker = false;
+
+    // Update repo state
+    openRepo(repoPath);
 
     // Save current tab state before creating new one
     syncGlobalToTab();
@@ -708,6 +720,15 @@
     ]}
     onSelect={handleReferenceFileSelect}
     onClose={() => (showFileSearch = false)}
+  />
+{/if}
+
+{#if showFolderPicker}
+  <FolderPickerModal
+    recentRepos={getRecentRepos()}
+    currentPath={repoState.currentPath}
+    onSelect={handleFolderSelect}
+    onClose={() => (showFolderPicker = false)}
   />
 {/if}
 

--- a/src/lib/FolderPickerModal.svelte
+++ b/src/lib/FolderPickerModal.svelte
@@ -1,0 +1,772 @@
+<!--
+  FolderPickerModal.svelte - Quick folder picker for opening repositories
+
+  Optimized for fast keyboard-driven folder opening:
+  - Starts at home directory
+  - Type to search folders recursively (fuzzy match)
+  - Recent repos shown for quick access
+  - Arrow keys to navigate, Enter to open/select
+-->
+<script lang="ts">
+  import { Folder, X, ChevronRight, Home, Clock, Search, Loader2, GitBranch } from 'lucide-svelte';
+  import { listDirectory, getHomeDir, searchDirectories, type DirEntry } from './services/files';
+  import type { RepoEntry } from './stores/repoState.svelte';
+
+  interface Props {
+    /** List of recent repositories */
+    recentRepos: RepoEntry[];
+    /** Called when a folder is selected */
+    onSelect: (path: string) => void;
+    /** Called when modal is closed */
+    onClose: () => void;
+    /** Current repo path (to show as disabled/current) */
+    currentPath?: string | null;
+  }
+
+  let { recentRepos, onSelect, onClose, currentPath = null }: Props = $props();
+
+  // State
+  let query = $state('');
+  let currentDir = $state('');
+  let entries = $state<DirEntry[]>([]);
+  let searchResults = $state<DirEntry[]>([]);
+  let loading = $state(false);
+  let searching = $state(false);
+  let error = $state<string | null>(null);
+  let homeDir = $state('');
+  let selectedIndex = $state(0);
+  let inputEl: HTMLInputElement | null = $state(null);
+  let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Are we in search mode (user has typed something)?
+  let isSearching = $derived(query.length > 0);
+
+  // Initialize
+  $effect(() => {
+    getHomeDir().then((dir) => {
+      homeDir = dir;
+      currentDir = dir;
+    });
+  });
+
+  // Focus input on mount
+  $effect(() => {
+    if (inputEl) {
+      inputEl.focus();
+    }
+  });
+
+  // Load directory when currentDir changes (only when not searching)
+  $effect(() => {
+    if (currentDir && !isSearching) {
+      loadDirectory(currentDir);
+    }
+  });
+
+  // Debounced search when query changes
+  $effect(() => {
+    if (searchTimeout) {
+      clearTimeout(searchTimeout);
+    }
+
+    // Need at least 2 chars to search (avoids expensive short queries)
+    if (!query || query.length < 2) {
+      searchResults = [];
+      searching = false;
+      return;
+    }
+
+    searching = true;
+
+    searchTimeout = setTimeout(async () => {
+      try {
+        // Search from current directory - use deeper search when at home
+        const depth = currentDir === homeDir ? 4 : 3;
+        const results = await searchDirectories(currentDir, query, depth, 20);
+        searchResults = results;
+        selectedIndex = 0;
+      } catch (e) {
+        console.error('Search failed:', e);
+        searchResults = [];
+      } finally {
+        searching = false;
+      }
+    }, 150);
+  });
+
+  // Reset selection when results change
+  $effect(() => {
+    if (!isSearching) {
+      const _ = entries;
+      selectedIndex = 0;
+    }
+  });
+
+  async function loadDirectory(path: string) {
+    loading = true;
+    error = null;
+
+    try {
+      const allEntries = await listDirectory(path);
+      // Only show directories
+      entries = allEntries.filter((e) => e.isDir);
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+      entries = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  // Filter recents by query
+  let filteredRecents = $derived.by(() => {
+    if (!query) return recentRepos.slice(0, 5);
+    const q = query.toLowerCase();
+    return recentRepos
+      .filter((r) => r.name.toLowerCase().includes(q) || r.path.toLowerCase().includes(q))
+      .slice(0, 5);
+  });
+
+  // Combined list for selection
+  let allItems = $derived.by(() => {
+    if (isSearching) {
+      // When searching: recents first, then search results
+      return [
+        ...filteredRecents.map((r) => ({ type: 'recent' as const, ...r })),
+        ...searchResults.map((e) => ({ type: 'search' as const, ...e })),
+      ];
+    } else {
+      // When browsing: recents (if at home), then directory entries
+      const showRecents = currentDir === homeDir;
+      return [
+        ...(showRecents ? filteredRecents.map((r) => ({ type: 'recent' as const, ...r })) : []),
+        ...entries.map((e) => ({ type: 'entry' as const, ...e })),
+      ];
+    }
+  });
+
+  function navigateTo(path: string) {
+    query = '';
+    currentDir = path;
+  }
+
+  function navigateUp() {
+    if (currentDir === '/') return;
+    const parent = currentDir.split('/').slice(0, -1).join('/') || '/';
+    navigateTo(parent);
+  }
+
+  function navigateHome() {
+    if (homeDir) {
+      navigateTo(homeDir);
+    }
+  }
+
+  function selectCurrent() {
+    onSelect(currentDir);
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      if (query) {
+        // Clear search first
+        query = '';
+        event.preventDefault();
+      } else {
+        onClose();
+        event.preventDefault();
+      }
+    } else if (event.key === 'Enter') {
+      const item = allItems[selectedIndex];
+      if (item) {
+        // Recent repos and search results are always repos - select them
+        // For directory entries, only select if it's a repo, otherwise drill in
+        if (item.type === 'recent' || item.type === 'search') {
+          if (item.path !== currentPath) {
+            onSelect(item.path);
+          }
+        } else if (item.type === 'entry') {
+          if (item.isRepo) {
+            onSelect(item.path);
+          } else {
+            // Not a repo - drill into it instead
+            navigateTo(item.path);
+          }
+        }
+      } else if (!isSearching && entries.length === 0) {
+        // No entries - select current folder
+        selectCurrent();
+      }
+      event.preventDefault();
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      selectedIndex = Math.min(selectedIndex + 1, allItems.length - 1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      selectedIndex = Math.max(selectedIndex - 1, 0);
+    } else if (event.key === 'ArrowLeft' && !isSearching) {
+      event.preventDefault();
+      navigateUp();
+    } else if (event.key === 'ArrowRight' || event.key === 'Tab') {
+      // Arrow right or Tab drills into the folder
+      const item = allItems[selectedIndex];
+      if (item && item.type !== 'recent') {
+        event.preventDefault();
+        navigateTo(item.path);
+      } else if (event.key === 'Tab') {
+        event.preventDefault(); // Prevent tab from leaving modal
+      }
+    } else if (event.key === 'Backspace' && !query && !isSearching) {
+      event.preventDefault();
+      navigateUp();
+    }
+  }
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  }
+
+  /**
+   * Highlight matching substring in text.
+   */
+  function highlightMatch(text: string, q: string): string {
+    if (!q) return escapeHtml(text);
+
+    const textLower = text.toLowerCase();
+    const queryLower = q.toLowerCase();
+    const idx = textLower.indexOf(queryLower);
+
+    if (idx === -1) return escapeHtml(text);
+
+    const before = escapeHtml(text.slice(0, idx));
+    const match = escapeHtml(text.slice(idx, idx + q.length));
+    const after = escapeHtml(text.slice(idx + q.length));
+
+    return `${before}<mark>${match}</mark>${after}`;
+  }
+
+  function escapeHtml(str: string): string {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /**
+   * Format path for display - collapse home directory to ~
+   */
+  function formatPath(path: string): string {
+    if (homeDir && path.startsWith(homeDir)) {
+      return '~' + path.slice(homeDir.length);
+    }
+    return path;
+  }
+
+  /**
+   * Get breadcrumb segments from a path.
+   */
+  function getBreadcrumbs(path: string): { name: string; path: string }[] {
+    const parts = path.split('/').filter(Boolean);
+    const crumbs: { name: string; path: string }[] = [];
+
+    let currentPath = '';
+    for (const part of parts) {
+      currentPath += '/' + part;
+      crumbs.push({ name: part, path: currentPath });
+    }
+
+    return crumbs;
+  }
+
+  // Track index where entries/search results start (after recents)
+  let firstNonRecentIndex = $derived(
+    isSearching ? filteredRecents.length : currentDir === homeDir ? filteredRecents.length : 0
+  );
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<div
+  class="modal-backdrop"
+  role="dialog"
+  aria-modal="true"
+  tabindex="-1"
+  onclick={handleBackdropClick}
+  onkeydown={(e) => e.key === 'Escape' && onClose()}
+>
+  <div class="modal">
+    <!-- Header with breadcrumbs -->
+    <div class="header">
+      <div class="breadcrumbs">
+        <button class="breadcrumb home" onclick={navigateHome} title="Home (~)">
+          <Home size={14} />
+        </button>
+        {#each getBreadcrumbs(currentDir) as crumb, i}
+          <ChevronRight size={12} class="separator" />
+          <button
+            class="breadcrumb"
+            class:current={i === getBreadcrumbs(currentDir).length - 1}
+            onclick={() => navigateTo(crumb.path)}
+          >
+            {crumb.name}
+          </button>
+        {/each}
+      </div>
+      <button class="close-btn" onclick={onClose} title="Close (Esc)">
+        <X size={18} />
+      </button>
+    </div>
+
+    <!-- Search input -->
+    <div class="search-container">
+      <div class="search-icon">
+        {#if searching}
+          <Loader2 size={16} class="spinner" />
+        {:else}
+          <Search size={16} />
+        {/if}
+      </div>
+      <input
+        bind:this={inputEl}
+        type="text"
+        class="search-input"
+        placeholder="Search folders..."
+        bind:value={query}
+        autocomplete="off"
+        spellcheck="false"
+      />
+      {#if query}
+        <button class="clear-btn" onclick={() => (query = '')} title="Clear">
+          <X size={14} />
+        </button>
+      {/if}
+    </div>
+
+    <!-- Results -->
+    <div class="results">
+      {#if loading && !isSearching}
+        <div class="empty-state">Loading...</div>
+      {:else if error && !isSearching}
+        <div class="empty-state error">{error}</div>
+      {:else}
+        <!-- Recent repos section -->
+        {#if filteredRecents.length > 0 && (isSearching || currentDir === homeDir)}
+          <div class="section-header">
+            <Clock size={12} />
+            <span>Recent</span>
+          </div>
+          {#each filteredRecents as repo, i (repo.path)}
+            {@const isCurrent = repo.path === currentPath}
+            {@const isSelected = i === selectedIndex}
+            <button
+              class="result recent-result"
+              class:selected={isSelected}
+              class:current={isCurrent}
+              onclick={() => !isCurrent && onSelect(repo.path)}
+              disabled={isCurrent}
+              onmouseenter={() => (selectedIndex = i)}
+            >
+              <Folder size={16} />
+              <div class="result-info">
+                <span class="result-name">{@html highlightMatch(repo.name, query)}</span>
+                <span class="result-path">{@html highlightMatch(formatPath(repo.path), query)}</span
+                >
+              </div>
+              {#if isCurrent}
+                <span class="badge">Current</span>
+              {:else}
+                <ChevronRight size={14} class="action-hint" />
+              {/if}
+            </button>
+          {/each}
+        {/if}
+
+        <!-- Search results or folder entries -->
+        {#if isSearching}
+          {#if searchResults.length > 0}
+            <div class="section-header">
+              <Search size={12} />
+              <span>Folders</span>
+            </div>
+            {#each searchResults as entry, i (entry.path)}
+              {@const isSelected = i + firstNonRecentIndex === selectedIndex}
+              <button
+                class="result"
+                class:selected={isSelected}
+                onclick={() => onSelect(entry.path)}
+                onmouseenter={() => (selectedIndex = i + firstNonRecentIndex)}
+              >
+                <Folder size={16} />
+                <div class="result-info">
+                  <span class="result-name">{@html highlightMatch(entry.name, query)}</span>
+                  <span class="result-path"
+                    >{@html highlightMatch(formatPath(entry.path), query)}</span
+                  >
+                </div>
+                <ChevronRight size={14} class="action-hint" />
+              </button>
+            {/each}
+          {:else if !searching && filteredRecents.length === 0}
+            <div class="empty-state">No matching folders</div>
+          {/if}
+        {:else if entries.length > 0}
+          {#if currentDir === homeDir && filteredRecents.length > 0}
+            <div class="section-header">
+              <Folder size={12} />
+              <span>Folders</span>
+            </div>
+          {/if}
+          {#each entries as entry, i (entry.path)}
+            {@const isSelected = i + firstNonRecentIndex === selectedIndex}
+            <button
+              class="result"
+              class:selected={isSelected}
+              class:is-repo={entry.isRepo}
+              onclick={() => (entry.isRepo ? onSelect(entry.path) : navigateTo(entry.path))}
+              onmouseenter={() => (selectedIndex = i + firstNonRecentIndex)}
+            >
+              {#if entry.isRepo}
+                <GitBranch size={16} class="repo-icon" />
+              {:else}
+                <Folder size={16} />
+              {/if}
+              <span class="result-name">{entry.name}</span>
+              <ChevronRight size={14} class="action-hint" />
+            </button>
+          {/each}
+        {:else if !loading && filteredRecents.length === 0}
+          <div class="empty-state">Empty directory</div>
+        {/if}
+      {/if}
+    </div>
+
+    <!-- Footer -->
+    <div class="footer">
+      <span class="hint">
+        <kbd>↑↓</kbd> navigate
+        <kbd>Enter</kbd> open
+        <kbd>Tab</kbd> drill in
+        <kbd>←</kbd> back
+      </span>
+      <button class="select-btn" onclick={selectCurrent}>
+        Open {formatPath(currentDir)}
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--shadow-overlay);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 12vh;
+    z-index: 1000;
+  }
+
+  .modal {
+    background: var(--bg-chrome);
+    border-radius: 12px;
+    box-shadow: var(--shadow-elevated);
+    width: 520px;
+    max-width: 90vw;
+    max-height: 65vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 12px 10px 16px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .breadcrumbs {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .breadcrumbs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .breadcrumb {
+    display: flex;
+    align-items: center;
+    padding: 4px 6px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-muted);
+    font-size: var(--size-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+      color 0.1s,
+      background-color 0.1s;
+  }
+
+  .breadcrumb:hover {
+    color: var(--text-primary);
+    background-color: var(--bg-hover);
+  }
+
+  .breadcrumb.current {
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .breadcrumb.home {
+    padding: 4px 6px;
+  }
+
+  .breadcrumbs :global(.separator) {
+    color: var(--text-faint);
+    flex-shrink: 0;
+  }
+
+  .close-btn,
+  .clear-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    background: none;
+    border: none;
+    border-radius: 4px;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition:
+      color 0.1s,
+      background-color 0.1s;
+  }
+
+  .close-btn:hover,
+  .clear-btn:hover {
+    color: var(--text-primary);
+    background-color: var(--bg-hover);
+  }
+
+  .search-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .search-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+  }
+
+  :global(.spinner) {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .search-input {
+    flex: 1;
+    padding: 4px 0;
+    background: none;
+    border: none;
+    font-size: var(--size-base);
+    color: var(--text-primary);
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: var(--text-faint);
+  }
+
+  .results {
+    flex: 1;
+    overflow-y: auto;
+    padding: 4px 0;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px 4px;
+    font-size: var(--size-xs);
+    color: var(--text-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .empty-state {
+    padding: 24px 16px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: var(--size-sm);
+  }
+
+  .empty-state.error {
+    color: var(--ui-danger);
+  }
+
+  .result {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 8px 16px;
+    background: none;
+    border: none;
+    text-align: left;
+    color: var(--text-primary);
+    font-size: var(--size-sm);
+    cursor: pointer;
+    transition: background-color 0.1s;
+  }
+
+  .result:hover,
+  .result.selected {
+    background-color: var(--bg-hover);
+  }
+
+  .result.current {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .result :global(svg) {
+    flex-shrink: 0;
+    color: var(--text-muted);
+  }
+
+  .result.is-repo :global(.repo-icon) {
+    color: var(--text-accent);
+  }
+
+  .result-info {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    overflow: hidden;
+    min-width: 0;
+  }
+
+  .result-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .result-name :global(mark) {
+    background: var(--bg-primary);
+    color: var(--text-accent);
+    border-radius: 2px;
+    padding: 0 1px;
+  }
+
+  .result-path {
+    font-size: var(--size-xs);
+    color: var(--text-muted);
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .result-path :global(mark) {
+    background: var(--bg-primary);
+    color: var(--text-accent);
+    border-radius: 2px;
+    padding: 0 1px;
+  }
+
+  .badge {
+    font-size: calc(var(--size-xs) - 1px);
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--bg-secondary);
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+
+  .result :global(.action-hint) {
+    color: var(--text-faint);
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.1s;
+  }
+
+  .result:hover :global(.action-hint),
+  .result.selected :global(.action-hint) {
+    opacity: 1;
+  }
+
+  .footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 16px;
+    border-top: 1px solid var(--border-subtle);
+    background: var(--bg-secondary);
+  }
+
+  .hint {
+    font-size: var(--size-xs);
+    color: var(--text-faint);
+  }
+
+  kbd {
+    display: inline-block;
+    padding: 2px 4px;
+    margin: 0 2px;
+    font-family: 'SF Mono', 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: calc(var(--size-xs) - 1px);
+    background: var(--bg-chrome);
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
+  }
+
+  .select-btn {
+    padding: 6px 12px;
+    background: var(--ui-accent);
+    border: none;
+    border-radius: 6px;
+    color: var(--bg-primary);
+    font-size: var(--size-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.1s;
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .select-btn:hover {
+    background: var(--ui-accent-hover);
+  }
+</style>

--- a/src/lib/services/files.ts
+++ b/src/lib/services/files.ts
@@ -2,6 +2,55 @@ import { invoke } from '@tauri-apps/api/core';
 import type { File } from '../types';
 
 // =============================================================================
+// Directory Browsing API
+// =============================================================================
+
+/**
+ * Entry in a directory listing.
+ */
+export interface DirEntry {
+  name: string;
+  path: string;
+  isDir: boolean;
+  isRepo: boolean;
+}
+
+/**
+ * List contents of a directory.
+ * Returns directories first (sorted), then files (sorted).
+ * Hidden files (starting with .) are excluded.
+ */
+export async function listDirectory(path: string): Promise<DirEntry[]> {
+  return invoke<DirEntry[]>('list_directory', { path });
+}
+
+/**
+ * Search for directories matching a query, recursively.
+ * Uses prefix/substring matching. Skips system folders and prioritizes dev locations.
+ * Returns up to `limit` matches sorted by relevance.
+ */
+export async function searchDirectories(
+  path: string,
+  query: string,
+  maxDepth?: number,
+  limit?: number
+): Promise<DirEntry[]> {
+  return invoke<DirEntry[]>('search_directories', {
+    path,
+    query,
+    maxDepth: maxDepth ?? 3,
+    limit: limit ?? 20,
+  });
+}
+
+/**
+ * Get the user's home directory path.
+ */
+export async function getHomeDir(): Promise<string> {
+  return invoke<string>('get_home_dir');
+}
+
+// =============================================================================
 // File Browsing API
 // =============================================================================
 

--- a/src/lib/stores/repoState.svelte.ts
+++ b/src/lib/stores/repoState.svelte.ts
@@ -5,7 +5,6 @@
  * Persists recent repos to localStorage.
  */
 
-import { open } from '@tauri-apps/plugin-dialog';
 import { getRepoRoot } from '../services/git';
 
 // =============================================================================
@@ -137,22 +136,10 @@ export function openRepo(path: string): void {
 }
 
 /**
- * Open a directory picker and set the selected directory as current repo.
- * Returns the selected path, or null if cancelled.
+ * Get recent repos for display in the folder picker modal.
  */
-export async function openRepoPicker(): Promise<string | null> {
-  const selected = await open({
-    directory: true,
-    multiple: false,
-    title: 'Select Repository',
-  });
-
-  if (selected && typeof selected === 'string') {
-    openRepo(selected);
-    return selected;
-  }
-
-  return null;
+export function getRecentRepos(): RepoEntry[] {
+  return repoState.recentRepos;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces the native OS folder picker with a custom modal optimized for keyboard-driven navigation.

## Features

- **Type to search**: Fuzzy matching for folder names, searches recursively
- **Recent repos**: Quick access to recently opened repositories  
- **Keyboard navigation**: Arrow keys to navigate, Enter to open/select
- **Git-aware**: Only shows git repositories in search results
- **Smart search**: At home directory, only searches common dev folders (dev, projects, code, etc.) to avoid slow scans

## Changes

### Backend (Rust)
- `list_directory`: Browse folder contents (dirs first, excludes hidden files)
- `search_directories`: Recursive repo search with relevance sorting
- `get_home_dir`: Get user's home directory path

### Frontend (Svelte)
- New `FolderPickerModal.svelte` component
- Updated `App.svelte` to use the new modal
- Added directory browsing API in `files.ts`
- Simplified `repoState.svelte.ts` (removed native dialog dependency)