### PR TITLE
Add window state persistence and macOS app menu

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4444,6 +4444,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
+ "tauri-plugin-window-state",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -4870,6 +4871,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.17",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.10.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5.0"
 tauri-plugin-clipboard-manager = "2.3.2"
+tauri-plugin-window-state = "2"
 reqwest = { version = "0.13.1", features = ["json"] }
 tokio = { version = "1.49.0", features = ["sync"] }
 open = "5"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "dialog:default",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "window-state:default"
   ]
 }

--- a/src-tauri/src/git/refs.rs
+++ b/src-tauri/src/git/refs.rs
@@ -46,7 +46,12 @@ pub fn detect_default_branch(repo: &Path) -> Result<String, GitError> {
     let refs = list_refs(repo)?;
 
     // Check for remote-tracking branches first (preferred for merge-base)
-    let remote_candidates = ["origin/main", "origin/master", "origin/develop", "origin/trunk"];
+    let remote_candidates = [
+        "origin/main",
+        "origin/master",
+        "origin/develop",
+        "origin/trunk",
+    ];
     for candidate in remote_candidates {
         if refs.iter().any(|r| r == candidate) {
             return Ok(candidate.to_string());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,8 +36,7 @@ fn make_diff_id(repo: &Path, spec: &DiffSpec) -> Result<DiffId, String> {
             GitRef::Rev(rev) => git::resolve_ref(repo, rev).map_err(|e| e.to_string()),
             GitRef::MergeBase => {
                 // Resolve merge-base to a concrete SHA for stable storage key
-                let default_branch =
-                    git::detect_default_branch(repo).map_err(|e| e.to_string())?;
+                let default_branch = git::detect_default_branch(repo).map_err(|e| e.to_string())?;
                 git::merge_base(repo, &default_branch, "HEAD").map_err(|e| e.to_string())
             }
         }
@@ -792,6 +791,28 @@ fn get_window_label(window: tauri::Window) -> String {
 fn build_menu(app: &AppHandle) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
     let menu = Menu::new(app)?;
 
+    // macOS app menu (required for Cmd+Q, Cmd+H, etc.)
+    #[cfg(target_os = "macos")]
+    {
+        let app_menu = Submenu::with_items(
+            app,
+            "Staged",
+            true,
+            &[
+                &PredefinedMenuItem::about(app, Some("About Staged"), None)?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::services(app, None)?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::hide(app, None)?,
+                &PredefinedMenuItem::hide_others(app, None)?,
+                &PredefinedMenuItem::show_all(app, None)?,
+                &PredefinedMenuItem::separator(app)?,
+                &PredefinedMenuItem::quit(app, None)?,
+            ],
+        )?;
+        menu.append(&app_menu)?;
+    }
+
     let file_menu = Submenu::with_items(
         app,
         "File",
@@ -858,6 +879,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_window_state::Builder::new().build())
         .setup(|app| {
             // Initialize the review store with app data directory
             review::init_store(app.handle()).map_err(|e| e.0)?;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -56,7 +56,6 @@
     selectPreset,
     selectCustomDiff,
     resetDiffSelection,
-
     type DiffPreset,
   } from './lib/stores/diffSelection.svelte';
   import {

--- a/src/lib/stores/diffSelection.svelte.ts
+++ b/src/lib/stores/diffSelection.svelte.ts
@@ -92,8 +92,6 @@ export function getPresets(): readonly DiffPreset[] {
   return presetStore.presets;
 }
 
-
-
 /**
  * Diff selection state object.
  * Use this directly in components - it's reactive!


### PR DESCRIPTION
## Changes

- **Window state persistence**: Added `tauri-plugin-window-state` to remember window size and position across sessions
- **macOS app menu**: Added proper app menu with standard macOS items:
  - About Staged
  - Services
  - Hide/Hide Others/Show All
  - Quit (Cmd+Q)
- Minor formatting fixes in `refs.rs` and `diffSelection.svelte.ts`

## Why

- Window state persistence improves UX by remembering user's preferred window configuration
- macOS app menu is expected behavior for native Mac apps and enables standard shortcuts like Cmd+Q