### PR TITLE
fix: remember References list per tab

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -32,6 +32,8 @@
   import { initWatcher, watchRepo, type Unsubscribe } from './lib/services/statusEvents';
   import { referenceFileAsDiff } from './lib/diffUtils';
   import {
+    referenceFilesState,
+    createReferenceFilesState,
     addReferenceFile,
     removeReferenceFile,
     loadReferenceFiles,
@@ -341,6 +343,10 @@
     diffSelection.label = tab.diffSelection.label;
     diffSelection.prNumber = tab.diffSelection.prNumber;
 
+    referenceFilesState.files = tab.referenceFilesState.files;
+    referenceFilesState.loading = tab.referenceFilesState.loading;
+    referenceFilesState.error = tab.referenceFilesState.error;
+
     // Update repo state
     setCurrentRepo(tab.repoPath);
   }
@@ -377,6 +383,10 @@
     tab.diffSelection.spec = diffSelection.spec;
     tab.diffSelection.label = diffSelection.label;
     tab.diffSelection.prNumber = diffSelection.prNumber;
+
+    tab.referenceFilesState.files = referenceFilesState.files;
+    tab.referenceFilesState.loading = referenceFilesState.loading;
+    tab.referenceFilesState.error = referenceFilesState.error;
   }
 
   /**
@@ -463,7 +473,8 @@
       createDiffState,
       createCommentsState,
       createDiffSelection,
-      createAgentState
+      createAgentState,
+      createReferenceFilesState
     );
 
     // Start watching the new repo (idempotent - won't restart if already watching)
@@ -577,7 +588,8 @@
         createDiffState,
         createCommentsState,
         createDiffSelection,
-        createAgentState
+        createAgentState,
+        createReferenceFilesState
       );
 
       // Initialize watcher listener once (handles all repos)
@@ -613,7 +625,8 @@
             createDiffState,
             createCommentsState,
             createDiffSelection,
-            createAgentState
+            createAgentState,
+            createReferenceFilesState
           );
         }
 

--- a/src/lib/stores/referenceFiles.svelte.ts
+++ b/src/lib/stores/referenceFiles.svelte.ts
@@ -24,13 +24,26 @@ export interface ReferenceFile {
   content: FileContent;
 }
 
-interface ReferenceFilesState {
+export interface ReferenceFilesState {
   /** Pinned reference files with loaded content */
   files: ReferenceFile[];
   /** Loading state for file fetching */
   loading: boolean;
   /** Error message if loading failed */
   error: string | null;
+}
+
+/**
+ * Create a new reference files state instance.
+ * Used to create isolated state per tab.
+ * Returns a plain object - reactivity comes from being stored in windowState.tabs.
+ */
+export function createReferenceFilesState(): ReferenceFilesState {
+  return {
+    files: [],
+    loading: false,
+    error: null,
+  };
 }
 
 export const referenceFilesState: ReferenceFilesState = $state({

--- a/src/lib/stores/tabState.svelte.ts
+++ b/src/lib/stores/tabState.svelte.ts
@@ -10,9 +10,10 @@ import type { DiffState } from './diffState.svelte';
 import type { CommentsState } from './comments.svelte';
 import type { DiffSelection } from './diffSelection.svelte';
 import type { AgentState } from './agent.svelte';
+import type { ReferenceFilesState } from './referenceFiles.svelte';
 
 // Re-export types for convenience
-export type { DiffState, CommentsState, DiffSelection, AgentState };
+export type { DiffState, CommentsState, DiffSelection, AgentState, ReferenceFilesState };
 
 /**
  * State for a single tab
@@ -30,6 +31,7 @@ export interface TabState {
   commentsState: CommentsState;
   diffSelection: DiffSelection;
   agentState: AgentState;
+  referenceFilesState: ReferenceFilesState;
 
   /** True if files changed while this tab was not active (needs refresh on switch) */
   needsRefresh: boolean;
@@ -83,7 +85,8 @@ export function addTab(
   createDiffState: () => DiffState,
   createCommentsState: () => CommentsState,
   createDiffSelection: () => DiffSelection,
-  createAgentState: () => AgentState
+  createAgentState: () => AgentState,
+  createReferenceFilesState: () => ReferenceFilesState
 ): void {
   // Check if tab already exists
   const existingIndex = windowState.tabs.findIndex((t) => t.id === repoPath);
@@ -103,6 +106,7 @@ export function addTab(
     commentsState: createCommentsState(),
     diffSelection: createDiffSelection(),
     agentState: createAgentState(),
+    referenceFilesState: createReferenceFilesState(),
     needsRefresh: false,
   };
 
@@ -209,7 +213,8 @@ export function loadTabsFromStorage(
   createDiffState: () => DiffState,
   createCommentsState: () => CommentsState,
   createDiffSelection: () => DiffSelection,
-  createAgentState: () => AgentState
+  createAgentState: () => AgentState,
+  createReferenceFilesState: () => ReferenceFilesState
 ): void {
   const key = `${STORAGE_KEY_PREFIX}${windowState.windowLabel}-tabs`;
   const stored = localStorage.getItem(key);
@@ -227,6 +232,7 @@ export function loadTabsFromStorage(
         commentsState: createCommentsState(),
         diffSelection: createDiffSelection(),
         agentState: createAgentState(),
+        referenceFilesState: createReferenceFilesState(),
         needsRefresh: false,
       }));
       windowState.activeTabIndex = data.activeTabIndex;


### PR DESCRIPTION
## Summary
Reference files are now isolated per tab instead of being shared globally. When switching between tabs, each tab's reference files are preserved and restored independently.

## Changes
- Added `referenceFilesState` to `TabState` interface
- Created `createReferenceFilesState()` factory function
- Updated tab sync logic to preserve reference files when switching tabs
- Updated tab initialization to create isolated reference file state