### PR TITLE
feat: add base branch selection when creating new branches

### DIFF
--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -15,7 +15,10 @@ pub use github::{
     check_github_auth, fetch_pr, invalidate_cache as invalidate_pr_cache, list_pull_requests,
     sync_review_to_github, GitHubAuthStatus, GitHubSyncResult, PullRequest,
 };
-pub use refs::{detect_default_branch, get_repo_root, list_refs, merge_base, resolve_ref};
+pub use refs::{
+    detect_default_branch, get_repo_root, list_branches, list_refs, merge_base, resolve_ref,
+    BranchRef,
+};
 pub use types::*;
 pub use worktree::{
     branch_exists, create_worktree, get_commits_since_base, get_head_sha, list_worktrees,

--- a/src/lib/services/branch.ts
+++ b/src/lib/services/branch.ts
@@ -19,6 +19,16 @@ export interface Branch {
   updatedAt: number;
 }
 
+/** A git branch reference for base branch selection */
+export interface BranchRef {
+  /** Short name (e.g., "main", "origin/main") */
+  name: string;
+  /** Whether this is a remote-tracking branch */
+  isRemote: boolean;
+  /** The remote name if this is a remote branch (e.g., "origin") */
+  remote: string | null;
+}
+
 /** Status of a branch session */
 export type BranchSessionStatus = 'running' | 'completed' | 'error';
 
@@ -76,10 +86,14 @@ export interface BranchNote {
 
 /**
  * Create a new branch with a worktree.
- * The branch is created from the repo's default branch.
+ * If baseBranch is not provided, uses the detected default branch.
  */
-export async function createBranch(repoPath: string, branchName: string): Promise<Branch> {
-  return invoke<Branch>('create_branch', { repoPath, branchName });
+export async function createBranch(
+  repoPath: string,
+  branchName: string,
+  baseBranch?: string
+): Promise<Branch> {
+  return invoke<Branch>('create_branch', { repoPath, branchName, baseBranch });
 }
 
 /**
@@ -101,6 +115,22 @@ export async function listBranches(): Promise<Branch[]> {
  */
 export async function listBranchesForRepo(repoPath: string): Promise<Branch[]> {
   return invoke<Branch[]>('list_branches_for_repo', { repoPath });
+}
+
+/**
+ * List git branches (local and remote) for base branch selection.
+ * Returns branches sorted with local first, then remote.
+ */
+export async function listGitBranches(repoPath: string): Promise<BranchRef[]> {
+  return invoke<BranchRef[]>('list_git_branches', { repoPath });
+}
+
+/**
+ * Detect the default branch for a repository.
+ * Returns the remote-tracking branch (e.g., "origin/main") if available.
+ */
+export async function detectDefaultBranch(repoPath: string): Promise<string> {
+  return invoke<string>('detect_default_branch', { repoPath });
 }
 
 /**


### PR DESCRIPTION

<img width="607" height="811" alt="Screenshot 2026-02-04 at 3 46 04 pm" src="https://github.com/user-attachments/assets/a5b49e0e-de18-4846-828b-65efeffeea1c" />
Adds an option to choose which local/remote branch to fork off from
I am finding this useful while we are working off the baxen/artifacts-workflow branch
Before, if i made a worktree and made it fork off another branch then Staged would show all the parent branch commits as well.