### PR TITLE
Store user prompt separately from full AI prompt

### DIFF
--- a/src/lib/NewSessionModal.svelte
+++ b/src/lib/NewSessionModal.svelte
@@ -80,8 +80,9 @@ Begin working on the task now.`;
     error = null;
 
     try {
-      const fullPrompt = buildCommitPrompt(prompt.trim());
-      const result = await startBranchSession(branch.id, fullPrompt);
+      const userPrompt = prompt.trim();
+      const fullPrompt = buildCommitPrompt(userPrompt);
+      const result = await startBranchSession(branch.id, userPrompt, fullPrompt);
 
       // Notify parent that session started
       onSessionStarted?.(result.branchSessionId, result.aiSessionId);

--- a/src/lib/services/branch.ts
+++ b/src/lib/services/branch.ts
@@ -208,12 +208,21 @@ export interface StartBranchSessionResponse {
 /**
  * Start a new session on a branch.
  * Creates a branch_session record, starts an AI session, and sends the prompt.
+ *
+ * @param branchId - The branch to start the session on
+ * @param userPrompt - The user's original prompt (stored for display)
+ * @param fullPrompt - The full prompt with context to send to the AI
  */
 export async function startBranchSession(
   branchId: string,
-  prompt: string
+  userPrompt: string,
+  fullPrompt: string
 ): Promise<StartBranchSessionResponse> {
-  return invoke<StartBranchSessionResponse>('start_branch_session', { branchId, prompt });
+  return invoke<StartBranchSessionResponse>('start_branch_session', {
+    branchId,
+    userPrompt,
+    fullPrompt,
+  });
 }
 
 /**


### PR DESCRIPTION
The commit preview was showing the full prompt with boilerplate context instead of just what the user typed. Now:

- startBranchSession accepts both userPrompt (for display) and fullPrompt (for AI)
- The user's original prompt is stored in the database for display
- The full prompt with context is only sent to the AI agent

This makes the session preview in BranchCard show the user's actual task instead of the system boilerplate.