### PR TITLE
fix: Disable autocorrect/autocapitalize on branch name input

### DIFF
--- a/src/lib/NewBranchModal.svelte
+++ b/src/lib/NewBranchModal.svelte
@@ -456,6 +456,10 @@
               type="text"
               placeholder="feature/my-feature"
               class="branch-input"
+              autocomplete="off"
+              autocorrect="off"
+              autocapitalize="off"
+              spellcheck="false"
             />
           </div>
 


### PR DESCRIPTION
When creating a new branch in Staged, the branch name input field now has autocorrect, autocapitalize, and spellcheck disabled. This prevents unwanted corrections when typing branch names that contain non-standard words or intentional lowercase text.