### PR TITLE
Add 'Open in...' button to branch cards

### DIFF
--- a/src/lib/services/branch.ts
+++ b/src/lib/services/branch.ts
@@ -352,3 +352,34 @@ export async function deleteBranchNote(noteId: string): Promise<void> {
 export async function recoverOrphanedNote(branchId: string): Promise<BranchNote | null> {
   return invoke<BranchNote | null>('recover_orphaned_note', { branchId });
 }
+
+// =============================================================================
+// Open In... Operations
+// =============================================================================
+
+/** An application that can open a directory */
+export interface OpenerApp {
+  /** Unique identifier (e.g., "vscode", "terminal", "warp") */
+  id: string;
+  /** Display name (e.g., "VS Code", "Terminal") */
+  name: string;
+}
+
+/**
+ * Get the list of supported apps that are currently installed.
+ * Results are cached for the lifetime of the app.
+ */
+let cachedOpeners: OpenerApp[] | null = null;
+
+export async function getAvailableOpeners(): Promise<OpenerApp[]> {
+  if (cachedOpeners !== null) return cachedOpeners;
+  cachedOpeners = await invoke<OpenerApp[]>('get_available_openers');
+  return cachedOpeners;
+}
+
+/**
+ * Open a directory path in a specific application.
+ */
+export async function openInApp(path: string, appId: string): Promise<void> {
+  return invoke<void>('open_in_app', { path, appId });
+}


### PR DESCRIPTION
## Summary

Adds an **Open** dropdown button to each branch card header, allowing users to quickly open a branch's worktree in their preferred app.

### How it works

1. Click **Open ▾** on any branch card
2. A dropdown lists all detected installed apps
3. Clicking an app opens the branch's worktree directory in it

### Supported apps (auto-detected via `mdfind`)

- **Editors**: VS Code, Cursor, Windsurf
- **Terminals**: Terminal, Warp, iTerm, Ghostty
- **Other**: GitHub Desktop, Finder

### Changes

| File | What |
|------|------|
| `src-tauri/src/lib.rs` | `get_available_openers` and `open_in_app` Tauri commands |
| `src/lib/services/branch.ts` | `OpenerApp` type, `getAvailableOpeners()`, `openInApp()` service functions |
| `src/lib/BranchCard.svelte` | Open button + dropdown UI in card header, removed `overflow: hidden` from card |

### Notes

- App detection uses macOS `mdfind` with bundle IDs — only installed apps appear
- Opening uses `open -b <bundle_id> <path>` — the standard macOS mechanism
- Removed `overflow: hidden` from `.branch-card` so the dropdown isn't clipped by the card boundary