### PR TITLE
Add delete buttons for commits and notes

### DIFF
--- a/src-tauri/src/git/mod.rs
+++ b/src-tauri/src/git/mod.rs
@@ -21,6 +21,6 @@ pub use refs::{
 };
 pub use types::*;
 pub use worktree::{
-    branch_exists, create_worktree, get_commits_since_base, get_head_sha, list_worktrees,
-    remove_worktree, worktree_path_for, CommitInfo,
+    branch_exists, create_worktree, get_commits_since_base, get_head_sha, get_parent_commit,
+    list_worktrees, remove_worktree, reset_to_commit, worktree_path_for, CommitInfo,
 };

--- a/src-tauri/src/git/worktree.rs
+++ b/src-tauri/src/git/worktree.rs
@@ -181,6 +181,23 @@ pub fn branch_exists(repo: &Path, branch_name: &str) -> Result<bool, GitError> {
     Ok(result.is_ok())
 }
 
+/// Reset HEAD to a specific commit (hard reset).
+/// This discards all commits after the specified commit.
+pub fn reset_to_commit(worktree: &Path, commit_sha: &str) -> Result<(), GitError> {
+    cli::run(worktree, &["reset", "--hard", commit_sha])?;
+    Ok(())
+}
+
+/// Get the parent commit SHA of a given commit.
+/// Returns None if the commit has no parent (initial commit).
+pub fn get_parent_commit(worktree: &Path, commit_sha: &str) -> Result<Option<String>, GitError> {
+    let result = cli::run(worktree, &["rev-parse", &format!("{}^", commit_sha)]);
+    match result {
+        Ok(output) => Ok(Some(output.trim().to_string())),
+        Err(_) => Ok(None), // No parent (initial commit or invalid)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1617,6 +1617,70 @@ fn cancel_branch_session(
         .map_err(|e| e.to_string())
 }
 
+/// Delete a branch session and its associated commit.
+/// This will also delete all commits that came after this one (reset to parent).
+/// Returns the number of commits that were removed.
+#[tauri::command(rename_all = "camelCase")]
+fn delete_branch_session_and_commit(
+    state: State<'_, Arc<Store>>,
+    branch_session_id: String,
+) -> Result<u32, String> {
+    // Get the session to find the commit SHA
+    let session = state
+        .get_branch_session(&branch_session_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Session '{}' not found", branch_session_id))?;
+
+    let commit_sha = session
+        .commit_sha
+        .as_ref()
+        .ok_or_else(|| "Session has no associated commit".to_string())?;
+
+    // Get the branch to find the worktree path
+    let branch = state
+        .get_branch(&session.branch_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Branch '{}' not found", session.branch_id))?;
+
+    let worktree = Path::new(&branch.worktree_path);
+
+    // Get the parent commit SHA (the commit we'll reset to)
+    let parent_sha = git::get_parent_commit(worktree, commit_sha)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "Cannot delete the initial commit".to_string())?;
+
+    // Count how many commits will be removed (from current HEAD to parent)
+    let commits_before =
+        git::get_commits_since_base(worktree, &parent_sha).map_err(|e| e.to_string())?;
+    let commits_removed = commits_before.len() as u32;
+
+    // Get all sessions for this branch to find which ones to delete
+    let all_sessions = state
+        .list_branch_sessions(&session.branch_id)
+        .map_err(|e| e.to_string())?;
+
+    // Find all sessions whose commits will be removed
+    // (commits that are descendants of the commit being deleted)
+    let commits_to_remove: std::collections::HashSet<String> =
+        commits_before.iter().map(|c| c.sha.clone()).collect();
+
+    // Delete sessions for commits that will be removed
+    for s in all_sessions {
+        if let Some(sha) = &s.commit_sha {
+            if commits_to_remove.contains(sha) {
+                state
+                    .delete_branch_session(&s.id)
+                    .map_err(|e| e.to_string())?;
+            }
+        }
+    }
+
+    // Reset the worktree to the parent commit
+    git::reset_to_commit(worktree, &parent_sha).map_err(|e| e.to_string())?;
+
+    Ok(commits_removed)
+}
+
 /// Recover orphaned sessions for a branch.
 /// If there's a "running" session but no live AI session, check if commits were made
 /// and mark the session as completed or errored accordingly.
@@ -2406,6 +2470,7 @@ pub fn run() {
             complete_branch_session,
             fail_branch_session,
             cancel_branch_session,
+            delete_branch_session_and_commit,
             recover_orphaned_session,
             get_branch_session_by_ai_session,
             get_branch_head,

--- a/src/lib/BranchCard.svelte
+++ b/src/lib/BranchCard.svelte
@@ -138,6 +138,11 @@
   // Delete note confirmation state
   let confirmingDeleteNoteId = $state<string | null>(null);
 
+  // Delete commit confirmation state
+  let confirmingDeleteCommitSha = $state<string | null>(null);
+  let commitsToDeleteCount = $state(0);
+  let deletingCommit = $state(false);
+
   // Load commits and running session on mount
   onMount(async () => {
     await loadData();
@@ -269,6 +274,48 @@
       console.error('Failed to delete note:', e);
     }
     confirmingDeleteNoteId = null;
+  }
+
+  // Start delete commit confirmation - calculate how many commits will be removed
+  function startDeleteCommit(commitSha: string) {
+    // Find the index of this commit (commits are newest-first)
+    const commitIndex = commits.findIndex((c) => c.sha === commitSha);
+    if (commitIndex === -1) return;
+
+    // All commits from index 0 to commitIndex (inclusive) will be deleted
+    // because they are newer or equal to the target commit
+    commitsToDeleteCount = commitIndex + 1;
+    confirmingDeleteCommitSha = commitSha;
+  }
+
+  async function handleDeleteCommit() {
+    if (!confirmingDeleteCommitSha) return;
+
+    // Find the session for this commit
+    const session = sessionsByCommit.get(confirmingDeleteCommitSha);
+    if (!session) {
+      console.error('No session found for commit:', confirmingDeleteCommitSha);
+      confirmingDeleteCommitSha = null;
+      return;
+    }
+
+    deletingCommit = true;
+    try {
+      await branchService.deleteBranchSessionAndCommit(session.id);
+      // Reload data to reflect the changes
+      await loadData();
+    } catch (e) {
+      console.error('Failed to delete commit:', e);
+    } finally {
+      deletingCommit = false;
+      confirmingDeleteCommitSha = null;
+      commitsToDeleteCount = 0;
+    }
+  }
+
+  function cancelDeleteCommit() {
+    confirmingDeleteCommitSha = null;
+    commitsToDeleteCount = 0;
   }
 
   function toggleDropdown() {
@@ -424,7 +471,11 @@
               class:is-head={item.isHead}
               class:has-session={!!item.session}
               onclick={() => {
-                if (item.session) handleViewSession(item.session);
+                if (confirmingDeleteCommitSha === item.commit.sha) {
+                  cancelDeleteCommit();
+                } else if (item.session) {
+                  handleViewSession(item.session);
+                }
               }}
             >
               <div class="timeline-marker">
@@ -450,28 +501,68 @@
                 </div>
               </div>
               <div class="timeline-actions">
-                {#if item.isHead}
+                {#if confirmingDeleteCommitSha === item.commit.sha}
+                  <div class="delete-confirm">
+                    {#if commitsToDeleteCount > 1}
+                      <span class="delete-warning">Will delete {commitsToDeleteCount} commits</span>
+                    {/if}
+                    <button
+                      class="delete-confirm-btn"
+                      disabled={deletingCommit}
+                      onclick={(e) => {
+                        e.stopPropagation();
+                        handleDeleteCommit();
+                      }}
+                    >
+                      {deletingCommit ? 'Deleting...' : 'Delete'}
+                    </button>
+                    <button
+                      class="delete-cancel-btn"
+                      disabled={deletingCommit}
+                      onclick={(e) => {
+                        e.stopPropagation();
+                        cancelDeleteCommit();
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                {:else}
+                  {#if item.isHead}
+                    <button
+                      class="action-btn"
+                      onclick={(e) => {
+                        e.stopPropagation();
+                        handleContinue();
+                      }}
+                    >
+                      <Play size={12} />
+                      Continue
+                    </button>
+                  {/if}
                   <button
-                    class="action-btn"
+                    class="action-btn action-btn-icon"
                     onclick={(e) => {
                       e.stopPropagation();
-                      handleContinue();
+                      onViewCommitDiff?.(item.commit.sha);
                     }}
+                    title="View diff"
                   >
-                    <Play size={12} />
-                    Continue
+                    <Eye size={12} />
                   </button>
+                  {#if item.session}
+                    <button
+                      class="action-btn action-btn-icon commit-delete"
+                      onclick={(e) => {
+                        e.stopPropagation();
+                        startDeleteCommit(item.commit.sha);
+                      }}
+                      title="Delete commit"
+                    >
+                      <Trash2 size={12} />
+                    </button>
+                  {/if}
                 {/if}
-                <button
-                  class="action-btn action-btn-icon"
-                  onclick={(e) => {
-                    e.stopPropagation();
-                    onViewCommitDiff?.(item.commit.sha);
-                  }}
-                  title="View diff"
-                >
-                  <Eye size={12} />
-                </button>
               </div>
             </div>
           {:else if item.type === 'note'}
@@ -1023,11 +1114,22 @@
     color: var(--ui-danger);
   }
 
-  /* Delete note confirmation inline */
+  .commit-delete:hover {
+    border-color: var(--ui-danger) !important;
+    color: var(--ui-danger) !important;
+  }
+
+  /* Delete confirmation inline */
   .delete-confirm {
     display: flex;
     align-items: center;
     gap: 4px;
+  }
+
+  .delete-warning {
+    font-size: var(--size-xs);
+    color: var(--ui-danger);
+    margin-right: 4px;
   }
 
   .delete-confirm-btn {

--- a/src/lib/services/branch.ts
+++ b/src/lib/services/branch.ts
@@ -254,6 +254,15 @@ export async function cancelBranchSession(branchSessionId: string): Promise<void
 }
 
 /**
+ * Delete a branch session and its associated commit.
+ * This will also delete all commits that came after this one (resets to parent).
+ * Returns the number of commits that were removed.
+ */
+export async function deleteBranchSessionAndCommit(branchSessionId: string): Promise<number> {
+  return invoke<number>('delete_branch_session_and_commit', { branchSessionId });
+}
+
+/**
  * Recover orphaned sessions for a branch.
  * If there's a "running" session but no live AI session, checks if commits were made
  * and marks the session as completed or errored accordingly.


### PR DESCRIPTION
- Add delete_branch_session_and_commit Tauri command that:
  - Finds the session's associated commit
  - Gets the parent commit SHA
  - Deletes all sessions for commits that will be removed
  - Resets the worktree to the parent commit (removing the commit and all subsequent commits)

- Add reset_to_commit and get_parent_commit git utilities in worktree.rs

- Add deleteBranchSessionAndCommit function to branch.ts service

- Update BranchCard.svelte with:
  - Delete button (trash icon) for commits that have sessions
  - Confirmation dialog warning that deleting a commit will also remove all commits after it
  - Shows count of commits that will be removed
  - Cancel/Delete buttons in confirmation state

Notes already had delete functionality via the existing delete_branch_note command.