### PR TITLE
fix: branch view UI polish

### DIFF
--- a/src/lib/BranchHome.svelte
+++ b/src/lib/BranchHome.svelte
@@ -247,7 +247,8 @@
   .branch-home {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     background-color: var(--bg-chrome);
   }
 

--- a/src/lib/BranchTopBar.svelte
+++ b/src/lib/BranchTopBar.svelte
@@ -73,7 +73,7 @@
     </button>
 
     <button
-      class="icon-btn"
+      class="icon-btn shortcuts-btn"
       onclick={() => (showShortcutsModal = !showShortcutsModal)}
       title="Keyboard shortcuts"
     >
@@ -81,7 +81,7 @@
     </button>
 
     <button
-      class="icon-btn"
+      class="icon-btn theme-btn"
       onclick={() => (showThemeModal = !showThemeModal)}
       title="Select theme (⌘P)"
     >

--- a/src/lib/KeyboardShortcutsModal.svelte
+++ b/src/lib/KeyboardShortcutsModal.svelte
@@ -155,15 +155,14 @@
 
 <style>
   .shortcuts-dropdown {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    margin-top: 4px;
+    position: fixed;
+    top: 40px;
+    right: 8px;
+    z-index: 1000;
     background: var(--bg-chrome);
     border: 1px solid var(--border-muted);
     border-radius: 8px;
     box-shadow: var(--shadow-elevated);
-    z-index: 100;
     width: 280px;
     display: flex;
     flex-direction: column;

--- a/src/lib/ThemeSelectorModal.svelte
+++ b/src/lib/ThemeSelectorModal.svelte
@@ -433,15 +433,14 @@
 
 <style>
   .theme-dropdown {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    margin-top: 4px;
+    position: fixed;
+    top: 40px;
+    right: 8px;
+    z-index: 1000;
     background: var(--bg-chrome);
     border: 1px solid var(--border-muted);
     border-radius: 8px;
     box-shadow: var(--shadow-elevated);
-    z-index: 100;
     width: 260px;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

A collection of small UI/UX fixes for the branch view.

### BranchCard commit rows
- Replace **Eye** icon with **FileDiff** for viewing commit diffs (clearer intent)
- Add **MessageSquare** icon for viewing AI sessions (explicit action)
- Remove implicit row click handler — both actions now have their own icon buttons
- Make **Continue** button hover-only like other action buttons (cleaner alignment)
- Clean up **note delete** button to use same pill style as commit row actions
- Swap **Open** and **⋮ menu** order in card header (Open rightmost)
- Remove extra vertical separator in dropdown menu

### Keyboard Shortcuts & Theme dropdowns
- Add `shortcuts-btn` / `theme-btn` classes so click-outside detection works (dropdowns were opening and immediately closing)
- Switch both modals from `position: absolute` to `position: fixed` to escape `overflow: hidden` clipping

### BranchHome layout
- Fix **New Branch** button being hidden below the scrollable area when many branch cards exist
- Changed `.branch-home` from `height: 100%` to `flex: 1; min-height: 0` so it fills remaining space after the top bar