### PR TITLE
Add rust-toolchain.toml to pin stable toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
This ensures new worktrees automatically use the stable Rust toolchain without needing to run `rustup default stable` manually.