### PR TITLE
feat(git): add MergeBaseOf variant for proper branch diff base computation

### DIFF
--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -38,17 +38,21 @@ pub enum GitRef {
     /// Merge-base between the default branch and HEAD.
     /// Resolved dynamically at diff-time to handle branch switches.
     MergeBase,
+    /// Merge-base between a specific branch and a head ref.
+    /// Format: [base_branch, head_ref] - computes merge-base(base_branch, head_ref)
+    MergeBaseOf([String; 2]),
 }
 
 impl GitRef {
     /// String representation for git commands
     /// WorkingTree is represented as empty string (git uses working tree by default)
-    /// MergeBase should be resolved before calling this
+    /// MergeBase/MergeBaseOf should be resolved before calling this
     pub fn as_git_arg(&self) -> Option<&str> {
         match self {
             GitRef::WorkingTree => None,
             GitRef::Rev(s) => Some(s),
             GitRef::MergeBase => panic!("MergeBase must be resolved before use"),
+            GitRef::MergeBaseOf(_) => panic!("MergeBaseOf must be resolved before use"),
         }
     }
 
@@ -58,6 +62,7 @@ impl GitRef {
             GitRef::WorkingTree => "@",
             GitRef::Rev(s) => s,
             GitRef::MergeBase => "merge-base",
+            GitRef::MergeBaseOf(_) => "merge-base",
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,10 @@ fn make_diff_id(repo: &Path, spec: &DiffSpec) -> Result<DiffId, String> {
                 let default_branch = git::detect_default_branch(repo).map_err(|e| e.to_string())?;
                 git::merge_base(repo, &default_branch, "HEAD").map_err(|e| e.to_string())
             }
+            GitRef::MergeBaseOf([base_branch, head_ref]) => {
+                // Resolve merge-base between specific refs
+                git::merge_base(repo, base_branch, head_ref).map_err(|e| e.to_string())
+            }
         }
     };
 

--- a/src/lib/BranchHome.svelte
+++ b/src/lib/BranchHome.svelte
@@ -261,7 +261,7 @@
     onViewDiff?.(
       branch.projectId,
       branch.worktreePath,
-      DiffSpec.fromRevs(branch.baseBranch, branch.branchName),
+      DiffSpec.mergeBaseDiff(branch.baseBranch, branch.branchName),
       `${branch.baseBranch}..${branch.branchName}`
     );
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,12 +6,14 @@
 export type GitRef =
   | { type: 'WorkingTree' }
   | { type: 'Rev'; value: string }
-  | { type: 'MergeBase' };
+  | { type: 'MergeBase' }
+  | { type: 'MergeBaseOf'; value: [string, string] };
 
 /** Get display string for a GitRef */
 export function gitRefDisplay(ref: GitRef): string {
   if (ref.type === 'WorkingTree') return '@';
   if (ref.type === 'MergeBase') return 'merge-base';
+  if (ref.type === 'MergeBaseOf') return 'merge-base';
   return ref.value;
 }
 
@@ -19,6 +21,7 @@ export function gitRefDisplay(ref: GitRef): string {
 export function gitRefName(ref: GitRef): string {
   if (ref.type === 'WorkingTree') return 'HEAD';
   if (ref.type === 'MergeBase') return 'HEAD'; // For file loading, use HEAD
+  if (ref.type === 'MergeBaseOf') return ref.value[1]; // Use head ref for file loading
   return ref.value;
 }
 
@@ -78,6 +81,14 @@ export const DiffSpec = {
     };
   },
 
+  /** Branch diff using merge-base: merge-base(baseBranch, headRef)..headRef */
+  mergeBaseDiff(baseBranch: string, headRef: string): DiffSpec {
+    return {
+      base: { type: 'MergeBaseOf', value: [baseBranch, headRef] },
+      head: { type: 'Rev', value: headRef },
+    };
+  },
+
   /** Custom range */
   custom(base: GitRef, head: GitRef): DiffSpec {
     return { base, head };
@@ -96,6 +107,7 @@ export const DiffSpec = {
     const formatRef = (ref: GitRef): string => {
       if (ref.type === 'WorkingTree') return '@';
       if (ref.type === 'MergeBase') return 'merge-base';
+      if (ref.type === 'MergeBaseOf') return 'merge-base';
       return ref.value;
     };
     return `${formatRef(spec.base)}..${formatRef(spec.head)}`;


### PR DESCRIPTION
The Branch view was using direct references (origin/main..branch-name) instead of computing the merge-base, which caused incorrect diffs when the base branch had new commits since the branch was created.

## Changes
- Add `MergeBaseOf([String; 2])` variant to `GitRef` enum in Rust
- Update `resolve_spec` to compute merge-base between the two specified refs
- Add `mergeBaseDiff` helper to TypeScript `DiffSpec`
- Update `BranchHome.svelte` to use `mergeBaseDiff` for branch diffs

This ensures branch diffs show only the changes introduced on the branch, not unrelated changes from the base branch.