### PR TITLE
Fix empty projects not appearing in branch home view

### DIFF
--- a/src/lib/BranchHome.svelte
+++ b/src/lib/BranchHome.svelte
@@ -344,7 +344,7 @@
     {:else}
       <!-- Branches grouped by project -->
       <div class="projects-list">
-        {#each [...branchesByProject.entries()].filter(([_, { branches: b, pending: p }]) => b.length > 0 || p.length > 0) as [projectId, { project, branches: projectBranches, pending: projectPending }] (projectId)}
+        {#each [...branchesByProject.entries()] as [projectId, { project, branches: projectBranches, pending: projectPending }] (projectId)}
           <div class="project-section">
             <div class="project-header">
               <div class="project-info">


### PR DESCRIPTION
## Summary

Fixes a bug where newly created projects with no branches yet wouldn't appear in the Branch Home view, preventing users from creating their first branch.

## Changes

- Removes the filter that hid projects without any branches or pending items, ensuring empty projects are visible so users can interact with them and create their first branch