### PR TITLE
Block UI render until preferences are loaded from storage

### DIFF
--- a/src/lib/stores/preferences.svelte.ts
+++ b/src/lib/stores/preferences.svelte.ts
@@ -111,6 +111,8 @@ export const preferences = $state({
   features: { ...DEFAULT_FEATURES } as Record<string, boolean>,
   /** Selected AI agent (null if not yet chosen) */
   aiAgent: null as string | null,
+  /** Whether all preferences have been loaded from storage */
+  loaded: false,
 });
 
 // =============================================================================
@@ -153,6 +155,31 @@ function applyAdaptiveTheme() {
  */
 export async function initPreferences(): Promise<void> {
   await initPersistentStore();
+}
+
+/**
+ * Load all preferences from storage.
+ * Sets preferences.loaded = true when complete.
+ * Returns { viewMode, hasAgent } for App.svelte to use.
+ */
+export async function loadAllPreferences(): Promise<{ viewMode: ViewMode; hasAgent: boolean }> {
+  // Load all preferences in parallel
+  await Promise.all([
+    loadSavedSize(),
+    loadSavedSidebarPosition(),
+    loadSavedSidebarWidth(),
+    loadSavedFeatures(),
+    loadSavedSyntaxTheme(),
+  ]);
+
+  // Load view mode and AI agent (these return values we need)
+  const viewMode = await loadSavedViewMode();
+  const hasAgent = await loadSavedAiAgent();
+
+  // Mark preferences as fully loaded
+  preferences.loaded = true;
+
+  return { viewMode, hasAgent };
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixes a race condition where the UI would briefly render with default preference values before the actual saved preferences loaded from Tauri's persistent store, causing a jarring flash of incorrect state.

## Changes

- Adds a `loaded` flag to the preferences store that gates UI rendering until all preferences are hydrated from storage
- Consolidates scattered preference loading calls into a single `loadAllPreferences()` function that atomically loads all settings and returns values needed by the app shell
- Shows a loading state instead of the main UI while preferences are being fetched, preventing the flash of default values
- Adds `onKeyChange` utility to the persistent store service for subscribing to storage key changes (infrastructure for future reactive preference updates)