### PR TITLE
Fix Cancel button visibility and simplify preference loading

### DIFF
--- a/src/lib/CreatePrModal.svelte
+++ b/src/lib/CreatePrModal.svelte
@@ -257,11 +257,14 @@
         </div>
 
         <div class="modal-actions">
-          {#if !isPushing && !isCreating}
-            <button type="button" class="btn btn-secondary" on:click={() => dispatch('close')}>
-              Cancel
-            </button>
-          {/if}
+          <button
+            type="button"
+            class="btn btn-secondary"
+            on:click={() => dispatch('close')}
+            disabled={isPushing || isCreating}
+          >
+            Cancel
+          </button>
           <button
             type="submit"
             class="btn btn-primary"


### PR DESCRIPTION
## Summary

Fixes a UX issue where the Cancel button would disappear during PR creation/update operations, and simplifies the preference loading architecture by removing unnecessary abstractions.

## Changes

- Keeps Cancel button always visible in CreatePrModal, using disabled state instead of conditional rendering during push/create operations
- Removes the `loadAllPreferences()` wrapper function in favor of direct parallel loading of individual preferences in App.svelte
- Eliminates the `preferences.loaded` flag and associated loading state UI, since async initialization already blocks rendering
- Simplifies `get_repo_root()` to use `--show-toplevel` directly instead of complex worktree detection logic
- Removes unused `onKeyChange` listener infrastructure from persistent store
- Removes the delete project button and confirmation dialog from BranchHome (empty projects are now filtered at render time)