### PR TITLE
feat: Prefill new session prompt with latest note title

### DIFF
--- a/src/lib/BranchCard.svelte
+++ b/src/lib/BranchCard.svelte
@@ -126,6 +126,27 @@
     return items;
   });
 
+  // Initial prompt for new commit (if latest item is a note)
+  let initialCommitPrompt = $derived.by(() => {
+    if (timeline.length === 0) return undefined;
+
+    // Get the latest non-running, non-generating item
+    let latestItem: TimelineItem | undefined;
+    for (let i = timeline.length - 1; i >= 0; i--) {
+      const item = timeline[i];
+      if (item.type === 'note' || item.type === 'commit') {
+        latestItem = item;
+        break;
+      }
+    }
+
+    if (latestItem && latestItem.type === 'note') {
+      return `Implement "${latestItem.note.title}"`;
+    }
+
+    return undefined;
+  });
+
   // Session viewer modal state (used for both commits and notes)
   let showSessionViewer = $state(false);
   let viewingSessionId = $state<string | null>(null);
@@ -901,6 +922,7 @@
     {branch}
     onClose={() => (showContinueModal = false)}
     onSessionStarted={handleSessionStarted}
+    initialPrompt={initialCommitPrompt}
   />
 {/if}
 

--- a/src/lib/NewSessionModal.svelte
+++ b/src/lib/NewSessionModal.svelte
@@ -19,12 +19,13 @@
     branch: Branch;
     onClose: () => void;
     onSessionStarted?: (branchSessionId: string, aiSessionId: string) => void;
+    initialPrompt?: string;
   }
 
-  let { branch, onClose, onSessionStarted }: Props = $props();
+  let { branch, onClose, onSessionStarted, initialPrompt }: Props = $props();
 
   // State
-  let prompt = $state('');
+  let prompt = $state(initialPrompt || '');
   let starting = $state(false);
   let error = $state<string | null>(null);
   let selectedProvider = $state<AcpProvider>((preferences.aiAgent as AcpProvider) || 'goose');


### PR DESCRIPTION
<img width="1092" height="1116" alt="Screenshot 2026-02-06 at 11 03 35 am" src="https://github.com/user-attachments/assets/7ca64c3f-a85d-488d-918b-cbdbc2c66f6e" />

## Summary

Improves the workflow for implementing planned work by automatically prefilling the new session prompt with the title of the most recent note, reducing friction when starting implementation.
If the latest activity on a branch is not a note, then there nothing is prefilled.

## Changes

- Automatically prefills the commit prompt with "Implement \"<note title>\"" when the latest timeline item is a note, creating a smoother transition from planning to implementation
- Adds `initialPrompt` prop to `NewSessionModal` to support prefilled prompts from parent components
- Removes unused "Copy Path" functionality from the branch card dropdown menu and its associated service function