### PR TITLE
fix: Preserve scroll position on data refresh in BranchHome

### DIFF
--- a/src/lib/BranchHome.svelte
+++ b/src/lib/BranchHome.svelte
@@ -355,6 +355,9 @@
   onDestroy(() => {
     window.removeEventListener('keydown', handleKeydown);
     unlistenStatus?.();
+    // Reset scroll state
+    savedScrollTop = 0;
+    shouldRestoreScroll = false;
   });
 </script>
 


### PR DESCRIPTION
## Summary

Fixes an annoying UX issue where the BranchHome view would jump back to the top whenever data refreshed, losing the user's place in potentially long lists of projects and branches.

## Changes

- Tracks scroll position before data refreshes and restores it after the DOM updates, using a two-phase effect pattern to handle Svelte's reactive update cycle
- Binds to the content container element to enable direct scroll position manipulation
- Cleans up scroll state on component unmount to prevent stale state issues