### PR TITLE
Fix cancel button behavior in new branch modal when opened from project context

### DIFF
--- a/src-tauri/src/ai/client.rs
+++ b/src-tauri/src/ai/client.rs
@@ -572,9 +572,18 @@ pub async fn run_acp_prompt_raw(
     working_dir: &Path,
     prompt: &str,
 ) -> Result<String, String> {
-    let result =
-        run_acp_prompt_internal(agent, working_dir, prompt, None, None, "", false, None, None)
-            .await?;
+    let result = run_acp_prompt_internal(
+        agent,
+        working_dir,
+        prompt,
+        None,
+        None,
+        "",
+        false,
+        None,
+        None,
+    )
+    .await?;
     Ok(result.response)
 }
 


### PR DESCRIPTION
## Summary

Fixes the new branch modal's cancel behavior when opened directly from a project context (with a pre-selected repo), ensuring cancel properly closes the modal instead of navigating back to a non-existent project selection step.

## Changes

- Closes the modal directly on cancel/escape when `initialRepoPath` is provided, since there's no project selection step to go back to
- Hides the back button on the name step when the repo is pre-selected, preventing navigation to an invalid state
- Ensures consistent escape key handling matches the updated cancel button behavior