### PR TITLE
fix: spinner was wobbling

### DIFF
--- a/src/lib/NewNoteModal.svelte
+++ b/src/lib/NewNoteModal.svelte
@@ -321,6 +321,7 @@
 
   :global(.spinning) {
     animation: spin 1s linear infinite;
+    transform-origin: center;
   }
 
   @keyframes spin {

--- a/src/lib/NewReviewModal.svelte
+++ b/src/lib/NewReviewModal.svelte
@@ -320,6 +320,7 @@ At the end, provide an overall assessment:
 
   :global(.spinning) {
     animation: spin 1s linear infinite;
+    transform-origin: center;
   }
 
   @keyframes spin {

--- a/src/lib/NewSessionModal.svelte
+++ b/src/lib/NewSessionModal.svelte
@@ -358,6 +358,7 @@
 
   :global(.spinning) {
     animation: spin 1s linear infinite;
+    transform-origin: center;
   }
 
   @keyframes spin {

--- a/src/lib/SessionViewerModal.svelte
+++ b/src/lib/SessionViewerModal.svelte
@@ -341,6 +341,7 @@
 
   :global(.spinning) {
     animation: spin 1s linear infinite;
+    transform-origin: center;
   }
 
   @keyframes spin {

--- a/src/lib/StreamingMessages.svelte
+++ b/src/lib/StreamingMessages.svelte
@@ -226,6 +226,7 @@
 
   :global(.spinning) {
     animation: spin 1s linear infinite;
+    transform-origin: center;
   }
 
   @keyframes spin {

--- a/src/lib/features/agent/AgentPanel.svelte
+++ b/src/lib/features/agent/AgentPanel.svelte
@@ -966,6 +966,7 @@
   .agent-send-btn :global(.spinning),
   .agent-response-header :global(.spinning) {
     animation: spin 1s linear infinite;
+    transform-origin: center;
   }
 
   @keyframes spin {


### PR DESCRIPTION
## Summary

Fixes a visual bug where spinning loader icons would wobble during rotation due to an off-center transform origin.

## Changes

- Adds `transform-origin: center` to all `.spinning` CSS classes across the codebase, ensuring icons rotate smoothly around their center point rather than wobbling during the spin animation