### PR TITLE
fix: show newlines in user prompts

### DIFF
--- a/src/lib/StreamingMessages.svelte
+++ b/src/lib/StreamingMessages.svelte
@@ -159,6 +159,7 @@
     color: var(--text-primary);
     line-height: 1.5;
     word-break: break-word;
+    white-space: pre-wrap;
   }
 
   /* Assistant message - no bubble, natural flow */


### PR DESCRIPTION
## Summary

Fixes formatting of user messages in the session viewer so that newlines in prompts are displayed as intended rather than collapsed into a single line.

## Changes

- Adds `white-space: pre-wrap` to user message bubbles to preserve intentional line breaks while still allowing text wrapping